### PR TITLE
Fix release workflow: use POSIX-compatible substring syntax

### DIFF
--- a/Makefile.cosmo
+++ b/Makefile.cosmo
@@ -69,7 +69,7 @@ release: cosmocc configure build
 	cp qe release/qe
 	cp tqe release/tqe
 	chmod +x release/qe release/tqe
-	tag="$$(date -u +%Y-%m-%d)-$${GITHUB_SHA::7}" && \
+	tag="$$(date -u +%Y-%m-%d)-$$(printf '%.7s' "$$GITHUB_SHA")" && \
 	(cd release && sha256sum qe tqe > SHA256SUMS && cat SHA256SUMS) && \
 	gh release create "$$tag" \
 		$$([ -z "$(RELEASE)" ] && echo --prerelease) \


### PR DESCRIPTION
## Summary

- The `release` target in `Makefile.cosmo` used bash-specific `${GITHUB_SHA::7}` substring syntax, but Make defaults to `/bin/sh` (dash on Ubuntu), which doesn't support this — causing the release job to fail with **exit code 2**
- Replaced with POSIX-compatible `printf '%.7s'` to extract the 7-char SHA prefix

## Test plan

- [ ] Verify the `release` workflow passes on this branch
- [ ] Confirm the generated tag format is correct (e.g. `2026-03-25-66841aa`)

https://claude.ai/code/session_01JbdU4RvdNZYCt3QarASdST