### PR TITLE
Sync kill ring with system clipboard via OSC 52

### DIFF
--- a/display.c
+++ b/display.c
@@ -118,6 +118,8 @@ static QEDisplay const dummy_dpy = {
 
     NULL, /* dpy_selection_activate */
     NULL, /* dpy_selection_request */
+    NULL, /* dpy_set_clipboard */
+    NULL, /* dpy_request_clipboard */
     NULL, /* dpy_invalidate */
     NULL, /* dpy_cursor_at */
     NULL, /* dpy_bmp_alloc */

--- a/display.h
+++ b/display.h
@@ -103,6 +103,8 @@ struct QEDisplay {
     /* These are optional, may be NULL */
     void (*dpy_selection_activate)(QEditScreen *s);
     void (*dpy_selection_request)(QEditScreen *s);
+    int (*dpy_set_clipboard)(QEditScreen *s);
+    int (*dpy_request_clipboard)(QEditScreen *s);
     void (*dpy_invalidate)(QEditScreen *s);
     void (*dpy_cursor_at)(QEditScreen *s, int x1, int y1, int w, int h);
 
@@ -198,6 +200,20 @@ static inline void selection_request(QEditScreen *s)
 {
     if (s->dpy.dpy_selection_request)
         s->dpy.dpy_selection_request(s);
+}
+
+static inline int dpy_set_clipboard(QEditScreen *s)
+{
+    if (s->dpy.dpy_set_clipboard)
+        return s->dpy.dpy_set_clipboard(s);
+    return -1;
+}
+
+static inline int dpy_request_clipboard(QEditScreen *s)
+{
+    if (s->dpy.dpy_request_clipboard)
+        return s->dpy.dpy_request_clipboard(s);
+    return -1;
 }
 
 static inline void dpy_invalidate(QEditScreen *s)

--- a/haiku.cpp
+++ b/haiku.cpp
@@ -883,6 +883,8 @@ static QEDisplay haiku_dpy = {
     haiku_set_clip,
     NULL, /* dpy_selection_activate */
     NULL, /* dpy_selection_request */
+    NULL, /* dpy_set_clipboard */
+    NULL, /* dpy_request_clipboard */
     NULL, /* dpy_invalidate */
     NULL, /* dpy_cursor_at */
     haiku_bmp_alloc, /* dpy_bmp_alloc */

--- a/html2png.c
+++ b/html2png.c
@@ -122,6 +122,8 @@ static QEDisplay ppm_dpy = {
     NULL, /* dpy_set_clip */
     NULL, /* dpy_selection_activate */
     NULL, /* dpy_selection_request */
+    NULL, /* dpy_set_clipboard */
+    NULL, /* dpy_request_clipboard */
     NULL, /* dpy_invalidate */
     NULL, /* dpy_cursor_at */
     NULL, /* dpy_bmp_alloc */

--- a/qe.c
+++ b/qe.c
@@ -2417,6 +2417,8 @@ void do_kill(EditState *s, int p1, int p2, int dir, int keep)
         qs->this_cmd_func = (CmdFunc)do_append_next_kill;
     }
     selection_activate(qs->screen);
+    /* push kill ring to system clipboard */
+    dpy_set_clipboard(qs->screen);
 }
 
 void do_kill_region(EditState *s) {
@@ -2536,6 +2538,9 @@ void do_yank(EditState *s) {
 
     /* if the GUI selection is used, it will be handled in the GUI code */
     selection_request(qs->screen);
+
+    /* pull system clipboard into kill ring if changed */
+    dpy_request_clipboard(qs->screen);
 
     s->b->mark = s->offset;
     b = qs->yank_buffers[qs->yank_current];

--- a/tty.c
+++ b/tty.c
@@ -793,11 +793,65 @@ static int tty_get_clipboard(QEditScreen *s, int ch)
 static int tty_request_clipboard(QEditScreen *s)
 {
     if (tty_clipboard == 1) {
-        qe_trace_bytes(s->qs, "tty-request-clipboard", -1, EB_TRACE_COMMAND);
+        QEmacsState *qs = s->qs;
+        int fd = fileno(s->STDIN);
+        int in_osc = 0, last_ch = 0;
+        fd_set rfds;
+        struct timeval tv;
+
+        qe_trace_bytes(qs, "tty-request-clipboard", -1, EB_TRACE_COMMAND);
         TTY_FPUTS("\033]52;;?\007", s->STDOUT);
         fflush(s->STDOUT);
-        // FIXME: should read tty response with a 100ms timeout
-        return 1;
+
+        /* Read OSC 52 response with timeout.
+         * Accumulate into qs->input_buf so tty_get_clipboard can parse it.
+         * Response format: ESC ] 52 ; <sel> ; <base64> BEL  or  ESC ] 52 ; <sel> ; <base64> ESC \
+         */
+        qs->input_len = 0;
+        for (;;) {
+            u8 buf[1];
+
+            FD_ZERO(&rfds);
+            FD_SET(fd, &rfds);
+            tv.tv_sec = 0;
+            tv.tv_usec = 200000;  /* 200ms timeout */
+            if (select(fd + 1, &rfds, NULL, NULL, &tv) <= 0)
+                break;
+            if (read(fd, buf, 1) != 1)
+                break;
+
+            int ch = buf[0];
+            /* grow input buffer if needed */
+            if (qs->input_len >= qs->input_size) {
+                qs->input_size += qs->input_size / 2 + 64;
+                if (qs->input_buf == qs->input_buf_def) {
+                    qs->input_buf = qe_malloc_bytes(qs->input_size);
+                    memcpy(qs->input_buf, qs->input_buf_def, qs->input_len);
+                } else {
+                    qe_realloc_bytes(&qs->input_buf, qs->input_size);
+                }
+            }
+            qs->input_buf[qs->input_len++] = ch;
+
+            if (!in_osc) {
+                /* waiting for ESC ] to start the OSC sequence */
+                if (ch == ']' && last_ch == '\033') {
+                    in_osc = 1;
+                    /* reset buffer to start of OSC: ESC ] */
+                    qs->input_len = 2;
+                    qs->input_buf[0] = '\033';
+                    qs->input_buf[1] = ']';
+                }
+            } else {
+                /* inside OSC, look for terminator: BEL or ESC \ */
+                if (ch == 7 || ch == 0x9C || (ch == '\\' && last_ch == '\033')) {
+                    tty_get_clipboard(s, ch);
+                    return 1;
+                }
+            }
+            last_ch = ch;
+        }
+        return 0;  /* timeout or no response */
     }
 #ifdef CONFIG_DARWIN
     if (tty_clipboard == 2) {
@@ -2210,6 +2264,8 @@ static QEDisplay tty_dpy = {
     tty_dpy_set_clip,
     NULL, /* dpy_selection_activate */
     NULL, /* dpy_selection_request */
+    tty_set_clipboard,
+    tty_request_clipboard,
     tty_dpy_invalidate,
     tty_dpy_cursor_at,
     tty_dpy_bmp_alloc,

--- a/win32.c
+++ b/win32.c
@@ -529,6 +529,8 @@ static QEDisplay win32_dpy = {
     win_set_clip,
     NULL, /* dpy_selection_activate */
     NULL, /* dpy_selection_request */
+    NULL, /* dpy_set_clipboard */
+    NULL, /* dpy_request_clipboard */
     NULL, /* dpy_invalidate */
     NULL, /* dpy_cursor_at */
     NULL, /* dpy_bmp_alloc */

--- a/x11.c
+++ b/x11.c
@@ -1977,6 +1977,8 @@ static QEDisplay x11_dpy = {
     x11_dpy_set_clip,
     x11_dpy_selection_activate,
     x11_dpy_selection_request,
+    NULL, /* dpy_set_clipboard */
+    NULL, /* dpy_request_clipboard */
     NULL, /* dpy_invalidate */
     NULL, /* dpy_cursor_at */
     x11_dpy_bmp_alloc,


### PR DESCRIPTION
## Summary

- Add `dpy_set_clipboard` / `dpy_request_clipboard` display driver ops, wiring OSC 52 clipboard sync into the kill/yank cycle
- On kill: push top of kill ring to system clipboard immediately (fire-and-forget)
- On yank: pull system clipboard with 200ms timeout, push into kill ring if changed, then yank as normal
- Previously clipboard sync only happened on focus-in/focus-out events

## Test plan

- [ ] Build with `./configure && make` — verified passing
- [ ] Run `make test` — all 66/66 tests pass
- [ ] Manual test in a terminal with OSC 52 support (kitty, iTerm2, WezTerm): kill text with C-k, verify it appears in system clipboard; copy text externally, verify C-y pastes it
- [ ] Manual test in a terminal without OSC 52: verify C-y falls back to local kill ring after 200ms timeout with no hang
- [ ] Verify `--clipboard 0` disables the new behavior

https://claude.ai/code/session_01SrHTEia7NuPVooTECr5Z8R