### PR TITLE
ci: restrict push trigger to master to avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/ci.yml'
   push:
     branches:
-      - '*'
+      - master
 
 jobs:
   ci:


### PR DESCRIPTION
Pushing to a branch with an open PR triggered both the `push` and
`pull_request` events, running CI twice for the same commit.

Fix: restrict `push` trigger to `master` only. Feature branches are
already covered by the `pull_request` trigger.