### PR TITLE
Fix M-x broken by synchronous clipboard read on focus events

### DIFF
--- a/tests/test_tty_input.c
+++ b/tests/test_tty_input.c
@@ -1,0 +1,218 @@
+/*
+ * TTY input handling tests for QEmacs
+ *
+ * Tests key input through a real PTY with the TTY driver, which
+ * exercises the full escape sequence parser and key composition.
+ * This complements test_terminal.c which uses the test display
+ * driver (bypassing the TTY escape sequence state machine).
+ *
+ * Copyright (c) 2026 Contributors.
+ * MIT License (same as QEmacs).
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pty.h>
+#include <sys/select.h>
+
+#include "testlib.h"
+
+#define QE_BINARY_DEFAULT  "../o/qe"
+static const char *qe_binary;
+
+/*--- PTY session helpers ---*/
+
+typedef struct {
+    pid_t pid;
+    int master_fd;
+} PTYSession;
+
+static int pty_start(PTYSession *ps) {
+    struct winsize ws = { .ws_row = 25, .ws_col = 80, .ws_xpixel = 0, .ws_ypixel = 0 };
+    char buf[65536];
+    int total = 0;
+
+    char ptyname[256];
+    ps->pid = forkpty(&ps->master_fd, ptyname, NULL, &ws);
+    if (ps->pid < 0)
+        return -1;
+
+    if (ps->pid == 0) {
+        /* child: run qe inside the PTY so the TTY driver is active */
+        setenv("QE_SESSION", "test", 1);
+        setenv("TERM", "xterm-256color", 1);
+        execlp(qe_binary, qe_binary, (char *)NULL);
+        _exit(1);
+    }
+
+    /* wait for qe to initialise and drain startup output */
+    usleep(500000);
+    for (int elapsed = 0; elapsed < 500; elapsed += 50) {
+        fd_set fds;
+        struct timeval tv;
+        FD_ZERO(&fds);
+        FD_SET(ps->master_fd, &fds);
+        tv.tv_sec = 0;
+        tv.tv_usec = 50000;
+        if (select(ps->master_fd + 1, &fds, NULL, NULL, &tv) > 0) {
+            int n = read(ps->master_fd, buf + total,
+                         sizeof(buf) - 1 - total);
+            if (n > 0) total += n;
+        }
+    }
+    return 0;
+}
+
+/* read until pattern is found or timeout_ms elapses */
+static int pty_read_until(PTYSession *ps, const char *pattern,
+                          int timeout_ms)
+{
+    char buf[65536];
+    int total = 0;
+    for (int elapsed = 0; elapsed < timeout_ms; elapsed += 50) {
+        fd_set fds;
+        struct timeval tv;
+        FD_ZERO(&fds);
+        FD_SET(ps->master_fd, &fds);
+        tv.tv_sec = 0;
+        tv.tv_usec = 50000;
+        if (select(ps->master_fd + 1, &fds, NULL, NULL, &tv) > 0) {
+            int n = read(ps->master_fd, buf + total,
+                         sizeof(buf) - 1 - total);
+            if (n > 0) {
+                total += n;
+                buf[total] = '\0';
+                if (strstr(buf, pattern))
+                    return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static void pty_stop(PTYSession *ps) {
+    if (ps->pid > 0) {
+        kill(ps->pid, SIGTERM);
+        waitpid(ps->pid, NULL, 0);
+        ps->pid = 0;
+    }
+    if (ps->master_fd >= 0) {
+        close(ps->master_fd);
+        ps->master_fd = -1;
+    }
+}
+
+/*--- Tests ---*/
+
+/* M-x via ESC then x through the TTY driver */
+TEST(tty_input, mx_esc_x)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    write(ps.master_fd, "\x1b", 1);
+    usleep(50000);
+    write(ps.master_fd, "x", 1);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/* M-x via modifyOtherKeys: CSI 27;3;120~ */
+TEST(tty_input, mx_modify_other_keys)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    write(ps.master_fd, "\033[27;3;120~", 11);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/* M-x via CSI u: CSI 120;3u */
+TEST(tty_input, mx_csi_u)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    write(ps.master_fd, "\033[120;3u", 8);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/* F2 (alternative execute-command binding): CSI 12~ */
+TEST(tty_input, mx_f2)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    write(ps.master_fd, "\033[12~", 5);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/* Regression: focus-in event must not consume subsequent M-x keystrokes.
+ *
+ * The TTY driver enables focus reporting (CSI ?1004h).  When the
+ * terminal sends a FocusIn event (CSI I), the handler requests the
+ * clipboard via OSC 52.  Previously the clipboard reader blocked
+ * synchronously for 200ms, consuming any user keystrokes that arrived
+ * during that window.  This broke M-x when the user switched windows
+ * (triggering FocusIn) and then typed ESC x. */
+TEST(tty_input, mx_after_focus_event)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    /* send FocusIn event */
+    write(ps.master_fd, "\033[I", 3);
+    usleep(100000);
+
+    /* send M-x via ESC then x */
+    write(ps.master_fd, "\x1b", 1);
+    usleep(50000);
+    write(ps.master_fd, "x", 1);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/* Focus event immediately followed by M-x in one write */
+TEST(tty_input, mx_focus_then_immediate_mx)
+{
+    PTYSession ps;
+    if (pty_start(&ps) != 0) { ASSERT_TRUE(0); return; }
+
+    write(ps.master_fd, "\033[I\x1bx", 5);
+
+    ASSERT_TRUE(pty_read_until(&ps, "Command:", 3000));
+    pty_stop(&ps);
+}
+
+/*--- Main ---*/
+
+int main(void)
+{
+    const char *env = getenv("QE_BINARY");
+    qe_binary = (env && *env) ? env : QE_BINARY_DEFAULT;
+
+    signal(SIGPIPE, SIG_IGN);
+
+    if (access(qe_binary, X_OK) != 0) {
+        fprintf(stderr, "ERROR: qe binary not found at '%s'\n", qe_binary);
+        return 1;
+    }
+
+    return testlib_run_all();
+}

--- a/tty.c
+++ b/tty.c
@@ -514,64 +514,16 @@ static int tty_request_clipboard(QEditScreen *s)
 {
     if (tty_clipboard == 1) {
         QEmacsState *qs = s->qs;
-        int fd = fileno(s->STDIN);
-        int in_osc = 0, last_ch = 0;
-        fd_set rfds;
-        struct timeval tv;
 
         qe_trace_bytes(qs, "tty-request-clipboard", -1, EB_TRACE_COMMAND);
+        /* Send OSC 52 clipboard query.  The response will arrive
+         * asynchronously and be handled by tty_read_handler's IS_OSC
+         * state which already calls tty_get_clipboard().  We must NOT
+         * do a blocking read here because it would consume user
+         * keystrokes that arrive before the terminal responds. */
         TTY_FPUTS("\033]52;;?\007", s->STDOUT);
         fflush(s->STDOUT);
-
-        /* Read OSC 52 response with timeout.
-         * Accumulate into qs->input_buf so tty_get_clipboard can parse it.
-         * Response format: ESC ] 52 ; <sel> ; <base64> BEL  or  ESC ] 52 ; <sel> ; <base64> ESC \
-         */
-        qs->input_len = 0;
-        for (;;) {
-            u8 buf[1];
-
-            FD_ZERO(&rfds);
-            FD_SET(fd, &rfds);
-            tv.tv_sec = 0;
-            tv.tv_usec = 200000;  /* 200ms timeout */
-            if (select(fd + 1, &rfds, NULL, NULL, &tv) <= 0)
-                break;
-            if (read(fd, buf, 1) != 1)
-                break;
-
-            int ch = buf[0];
-            /* grow input buffer if needed */
-            if (qs->input_len >= qs->input_size) {
-                qs->input_size += qs->input_size / 2 + 64;
-                if (qs->input_buf == qs->input_buf_def) {
-                    qs->input_buf = qe_malloc_bytes(qs->input_size);
-                    memcpy(qs->input_buf, qs->input_buf_def, qs->input_len);
-                } else {
-                    qe_realloc_bytes(&qs->input_buf, qs->input_size);
-                }
-            }
-            qs->input_buf[qs->input_len++] = ch;
-
-            if (!in_osc) {
-                /* waiting for ESC ] to start the OSC sequence */
-                if (ch == ']' && last_ch == '\033') {
-                    in_osc = 1;
-                    /* reset buffer to start of OSC: ESC ] */
-                    qs->input_len = 2;
-                    qs->input_buf[0] = '\033';
-                    qs->input_buf[1] = ']';
-                }
-            } else {
-                /* inside OSC, look for terminator: BEL or ESC \ */
-                if (ch == 7 || ch == 0x9C || (ch == '\\' && last_ch == '\033')) {
-                    tty_get_clipboard(s, ch);
-                    return 1;
-                }
-            }
-            last_ch = ch;
-        }
-        return 0;  /* timeout or no response */
+        return 0;
     }
     return -1;
 }


### PR DESCRIPTION
## Problem

After #40 ("Simplify TTY driver assuming Ghostty as sole terminal target"), M-x stopped working when typed shortly after the terminal window gained focus.

## Root Cause

The TTY simplification unconditionally enables focus reporting (`\033[?1004h`) and clipboard sync (`tty_clipboard=1`). When a FocusIn event (`CSI I`) arrives, the handler calls `tty_request_clipboard()`, which sent an OSC 52 query and then **blocked for up to 200ms** reading the response byte-by-byte directly from stdin. Any keystrokes arriving during that window (like ESC + x for M-x) were consumed by the clipboard reader instead of the normal key handler.

Previously these features were only enabled for terminals known to support them; the old code disabled them entirely when `TERM_PROGRAM=qemacs` (i.e. running inside a qe shell/session).

## Fix

Make `tty_request_clipboard()` non-blocking: send the OSC 52 query and return immediately. The response arrives asynchronously through `tty_read_handler`'s existing `IS_OSC` state, which already calls `tty_get_clipboard()`.

**tty.c**: -54 lines (remove blocking read loop), +6 lines (async send + comment).

## Tests

Add `tests/test_tty_input.c` — 6 tests exercising key input through a real PTY (TTY driver, not test display):

| Test | Description |
|------|-------------|
| `mx_esc_x` | Traditional ESC then x |
| `mx_modify_other_keys` | CSI 27;3;120~ format |
| `mx_csi_u` | CSI 120;3u format |
| `mx_f2` | F2 alternative binding |
| **`mx_after_focus_event`** | **Regression**: M-x 100ms after FocusIn |
| **`mx_focus_then_immediate_mx`** | **Regression**: FocusIn + M-x in one write |

The two regression tests fail without the fix and pass with it.