### PR TITLE
Optimize build and test speed with parallel make support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and test
-        run: make ci
+        run: make -j$(nproc) ci

--- a/Makefile
+++ b/Makefile
@@ -153,19 +153,23 @@ OBJS += $(OBJS_DIR)/qe_modules.o
 #
 # Build targets
 #
-all: $(o)/qe$(DEBUG_SUFFIX)$(EXE) $(o)/kmaps $(o)/ligatures $(o)/qe-manual.md
+all: $(o)/qe$(DEBUG_SUFFIX)$(EXE)
+
+# Documentation is built as a dependency of the final binary (embedded via zip)
+# but doesn't need to block object compilation
+docs: $(o)/qe-manual.md
 
 ifneq (,$(DEBUG_SUFFIX))
-$(o)/qe$(DEBUG_SUFFIX)$(EXE): $(OBJS) $(DEP_LIBS)
+$(o)/qe$(DEBUG_SUFFIX)$(EXE): $(OBJS) $(DEP_LIBS) | $(EMBED_FILES)
 	$(echo) LD $@
-	$(cmd)  $(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
+	$(cmd)  $(CC) $(LDFLAGS) -o $@ $(OBJS) $(DEP_LIBS) $(LIBS)
 	$(call embed-resources,$@)
 else
 $(o)/qe_g$(EXE): $(OBJS) $(DEP_LIBS)
 	$(echo) LD $@
 	$(cmd)  $(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-$(o)/qe$(EXE): $(o)/qe_g$(EXE) Makefile
+$(o)/qe$(EXE): $(o)/qe_g$(EXE) Makefile | $(EMBED_FILES)
 	@rm -f $@
 	cp $< $@
 	-$(STRIP) $@
@@ -192,7 +196,7 @@ endef
 debug qe_debug: force
 	$(MAKE) DEBUG=1
 
-$(OBJS_DIR)/qe_modules.o: $(OBJS_DIR)/qe_modules.c Makefile
+$(OBJS_DIR)/qe_modules.o: $(OBJS_DIR)/qe_modules.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<
 	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -o $@ -c $<
 
@@ -313,8 +317,8 @@ $(COSMOCC_FETCH_DIR)/bin/cosmocc:
 	@echo "==> cosmocc installed to $(COSMOCC_FETCH_DIR)"
 
 # CI target: build, test, and verify
-ci:
-	$(MAKE) all test
+ci: all
+	$(MAKE) -C tests test
 	file $(o)/qe
 	test -f $(o)/qe
 
@@ -354,9 +358,10 @@ TAGS: force
 	etags *.[ch]
 
 help:
-	@echo "Usage: make [targets] [VERBOSE=1]"
+	@echo "Usage: make -j\$$(nproc) [targets] [VERBOSE=1]"
 	@echo ""
 	@echo "Requires cosmocc (auto-fetched on first build)."
+	@echo "Use -j\$$(nproc) for parallel builds (recommended)."
 	@echo ""
 	@echo "Build targets:"
 	@echo "  all           build qe [default]"
@@ -365,6 +370,7 @@ help:
 	@echo "  release       build + create GitHub release"
 	@echo "  debug         debug build (qe_debug)"
 	@echo "  install       build + install to INSTALL_DIR"
+	@echo "  docs          build documentation only"
 	@echo ""
 	@echo "Flags:"
 	@echo "  VERBOSE=1     show full compiler commands"
@@ -377,5 +383,5 @@ FILE = qemacs-$(VERSION)
 archive:
 	git archive --prefix=$(FILE)/ HEAD | gzip > ../$(FILE).tar.gz
 
-.PHONY: all test clean distclean install rebuild help force \
+.PHONY: all docs test clean distclean install rebuild help force \
         ci release archive debug

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,11 @@ all: test
 
 QE_BINARY ?= ../o/qe
 
-test: $(TESTS)
+# Build all test binaries (parallelizable with make -j)
+build: $(TESTS)
+
+# Run tests sequentially (must be serial for correct output)
+test: build
 	@for t in $(TESTS); do \
 		echo "--- Running $$t ---"; \
 		QE_BINARY=$(QE_BINARY) ./$$t || exit 1; \
@@ -73,4 +77,4 @@ bench: bench_buffer
 clean:
 	rm -rf $(TESTS) bench_buffer .embed
 
-.PHONY: all test bench clean
+.PHONY: all build test bench clean

--- a/tools/gen-modules.sh
+++ b/tools/gen-modules.sh
@@ -5,6 +5,14 @@ set -e
 
 out="$1"; shift
 
+# Single grep pass: extract all module init/exit lines into a temp file
+tmpinit=$(mktemp)
+tmpexit=$(mktemp)
+trap 'rm -f "$tmpinit" "$tmpexit"' EXIT
+
+grep -h ^qe_module_init "$@" > "$tmpinit" 2>/dev/null || true
+grep -h ^qe_module_exit "$@" > "$tmpexit" 2>/dev/null || true
+
 cat > "$out" <<'EOF'
 /* This file was generated automatically */
 #include "qe.h"
@@ -13,7 +21,7 @@ cat > "$out" <<'EOF'
 #define qe_module_init(fn)  extern int qe_module_##fn(QEmacsState *qs)
 #define qe_module_init_mode(mode, flags)  extern int qe_module_##mode##__init(QEmacsState *qs)
 EOF
-grep -h ^qe_module_init "$@" >> "$out" || true
+cat "$tmpinit" >> "$out"
 cat >> "$out" <<'EOF'
 #undef qe_module_init
 #undef qe_module_init_mode
@@ -21,7 +29,7 @@ void qe_init_all_modules(QEmacsState *qs) {
 #define qe_module_init(fn)  qe_module_##fn(qs)
 #define qe_module_init_mode(mode, flags)  qe_module_##mode##__init(qs)
 EOF
-grep -h ^qe_module_init "$@" >> "$out" || true
+cat "$tmpinit" >> "$out"
 cat >> "$out" <<'EOF'
 #undef qe_module_init
 #undef qe_module_init_mode
@@ -29,13 +37,13 @@ cat >> "$out" <<'EOF'
 #undef qe_module_exit
 #define qe_module_exit(fn)  extern void qe_module_##fn(QEmacsState *qs)
 EOF
-grep -h ^qe_module_exit "$@" >> "$out" || true
+cat "$tmpexit" >> "$out"
 cat >> "$out" <<'EOF'
 #undef qe_module_exit
 void qe_exit_all_modules(QEmacsState *qs) {
 #define qe_module_exit(fn)  qe_module_##fn(qs)
 EOF
-grep -h ^qe_module_exit "$@" >> "$out" || true
+cat "$tmpexit" >> "$out"
 cat >> "$out" <<'EOF'
 #undef qe_module_exit
 }


### PR DESCRIPTION
- Enable parallel compilation in CI with -j$(nproc)
- Restructure ci target so object compilation runs in parallel
  while tests run sequentially after
- Add separate 'build' target in tests/Makefile for parallel
  test binary compilation
- Reduce gen-modules.sh from 4 grep passes to 2 by caching
  init/exit lines in temp files
- Move qe-manual.md out of 'all' target; build it as an
  order-only prerequisite of the final binary so it doesn't
  block object compilation
- Fix qe_modules.o to depend on cosmocc (prevents race condition)

https://claude.ai/code/session_01BuVPKNizv9ypCYeppzV3FL