### PR TITLE
fix session server deadlock when client terminal dies

### DIFF
--- a/session.c
+++ b/session.c
@@ -162,7 +162,13 @@ static int alternate_buffer;
  * I/O helpers
  *------------------------------------------------------------------------*/
 
-static ssize_t write_all(int fd, const char *buf, size_t len) {
+/*
+ * write_all_timeout: write all bytes with a bounded poll timeout.
+ * timeout_ms: milliseconds to wait per EAGAIN (-1 = infinite, 0 = no wait).
+ * Returns number of bytes written, or -1 on error/timeout.
+ */
+static ssize_t write_all_timeout(int fd, const char *buf, size_t len,
+                                 int timeout_ms) {
     ssize_t ret = len;
     while (len > 0) {
         ssize_t res = write(fd, buf, len);
@@ -170,8 +176,14 @@ static ssize_t write_all(int fd, const char *buf, size_t len) {
             if (errno == EINTR)
                 continue;
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                if (timeout_ms == 0)
+                    return -1;
                 struct pollfd pfd = { .fd = fd, .events = POLLOUT };
-                poll(&pfd, 1, -1);
+                int pr = poll(&pfd, 1, timeout_ms);
+                if (pr <= 0)
+                    return -1;  /* timeout or poll error */
+                if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
+                    return -1;
                 continue;
             }
             return -1;
@@ -182,6 +194,10 @@ static ssize_t write_all(int fd, const char *buf, size_t len) {
         len -= res;
     }
     return ret;
+}
+
+static ssize_t write_all(int fd, const char *buf, size_t len) {
+    return write_all_timeout(fd, buf, len, -1);
 }
 
 static ssize_t read_all(int fd, char *buf, size_t len) {
@@ -208,6 +224,17 @@ static int send_packet(int fd, Packet *pkt) {
     if (size > sizeof(*pkt))
         return -1;
     return write_all(fd, (char *)pkt, size) == (ssize_t)size ? 0 : -1;
+}
+
+/*
+ * send_packet_nonblock: try to send a packet without blocking.
+ * Returns 0 on success, -1 if the write would block or fails.
+ */
+static int send_packet_nonblock(int fd, Packet *pkt) {
+    size_t size = packet_size(pkt);
+    if (size > sizeof(*pkt))
+        return -1;
+    return write_all_timeout(fd, (char *)pkt, size, 0) == (ssize_t)size ? 0 : -1;
 }
 
 static int recv_packet(int fd, Packet *pkt) {
@@ -582,8 +609,16 @@ static void server_mainloop(void) {
 
             FD_SET_MAX(c->socket, &new_readfds, new_fdmax);
 
-            if (pty_data)
-                send_packet(c->socket, &server_pkt);
+            if (pty_data) {
+                if (send_packet_nonblock(c->socket, &server_pkt) < 0)
+                    c->state = STATE_DISCONNECTED;
+            }
+
+            if (c->state == STATE_DISCONNECTED) {
+                prev_next = &c->next;
+                c = c->next;
+                continue;
+            }
 
             if (!server.running) {
                 if (server.exit_status != -1) {
@@ -716,7 +751,10 @@ static int client_mainloop(void) {
             if (recv_packet(client.server_socket, &rpkt) == 0) {
                 switch (rpkt.type) {
                 case MSG_CONTENT:
-                    write_all(STDOUT_FILENO, rpkt.u.msg, rpkt.len);
+                    if (write_all_timeout(STDOUT_FILENO, rpkt.u.msg,
+                                          rpkt.len, 5000) < 0) {
+                        client.running = 0;  /* terminal dead, disconnect */
+                    }
                     break;
                 case MSG_RESIZE:
                     client.need_resize = 1;

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -1592,6 +1592,175 @@ TEST(io, write_all_to_closed_pipe) {
     close(fds[0]);
 }
 
+/* ---- write_all_timeout tests ---- */
+
+TEST(io, write_all_timeout_basic) {
+    /* write_all_timeout with generous timeout should succeed normally */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    ssize_t ret = write_all_timeout(fds[0], "hello", 5, 5000);
+    ASSERT_EQ(ret, 5);
+
+    char buf[8];
+    memset(buf, 0, sizeof(buf));
+    ASSERT_EQ(read_all(fds[1], buf, 5), 5);
+    ASSERT_MEMEQ(buf, "hello", 5);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(io, write_all_timeout_to_closed_pipe) {
+    /* write_all_timeout to a closed socket should return -1, not hang */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    close(fds[1]);  /* close reader */
+
+    struct sigaction sa, old_sa;
+    sa.sa_handler = SIG_IGN;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGPIPE, &sa, &old_sa);
+
+    ssize_t ret = write_all_timeout(fds[0], "data", 4, 1000);
+    ASSERT_TRUE(ret == -1);
+
+    sigaction(SIGPIPE, &old_sa, NULL);
+    close(fds[0]);
+}
+
+TEST(io, write_all_timeout_returns_on_full_buffer) {
+    /* When the socket buffer is full and the reader is gone,
+     * write_all_timeout must return -1 within the timeout period,
+     * NOT block forever like the old write_all did.
+     * This is the core test for issue #47. */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+    /* Set non-blocking so writes return EAGAIN when buffer full */
+    set_socket_non_blocking(fds[0]);
+
+    /* Fill the send buffer */
+    char big[4096];
+    memset(big, 'x', sizeof(big));
+    for (int i = 0; i < 1000; i++) {
+        ssize_t w = write(fds[0], big, sizeof(big));
+        if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            break;
+    }
+
+    /* Now write_all_timeout with a short timeout should fail, not block */
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    ssize_t ret = write_all_timeout(fds[0], "more", 4, 200);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
+                      (end.tv_nsec - start.tv_nsec) / 1000000;
+
+    /* Must return failure (-1), indicating timeout/error */
+    ASSERT_TRUE(ret == -1);
+    /* Must return within reasonable time (not infinite) */
+    ASSERT_TRUE(elapsed_ms < 5000);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(io, write_all_timeout_zero_means_nonblocking) {
+    /* timeout_ms=0 should mean pure non-blocking: no poll at all */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    set_socket_non_blocking(fds[0]);
+
+    /* Fill the send buffer */
+    char big[4096];
+    memset(big, 'x', sizeof(big));
+    for (int i = 0; i < 1000; i++) {
+        ssize_t w = write(fds[0], big, sizeof(big));
+        if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            break;
+    }
+
+    /* With timeout=0, should fail immediately on full buffer */
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    ssize_t ret = write_all_timeout(fds[0], "data", 4, 0);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
+                      (end.tv_nsec - start.tv_nsec) / 1000000;
+
+    ASSERT_TRUE(ret == -1);
+    ASSERT_TRUE(elapsed_ms < 100);  /* should be nearly instant */
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+/* ---- send_packet_nonblock tests ---- */
+
+TEST(io, send_packet_nonblock_basic) {
+    /* send_packet_nonblock should succeed on a writable socket */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    set_socket_non_blocking(fds[0]);
+
+    Packet out;
+    memset(&out, 0, sizeof(out));
+    out.type = MSG_CONTENT;
+    out.len = 5;
+    memcpy(out.u.msg, "hello", 5);
+    ASSERT_EQ(send_packet_nonblock(fds[0], &out), 0);
+
+    Packet in;
+    memset(&in, 0, sizeof(in));
+    ASSERT_EQ(recv_packet(fds[1], &in), 0);
+    ASSERT_EQ(in.type, MSG_CONTENT);
+    ASSERT_EQ(in.len, 5);
+    ASSERT_MEMEQ(in.u.msg, "hello", 5);
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
+TEST(io, send_packet_nonblock_full_buffer) {
+    /* send_packet_nonblock must return -1 when buffer is full, not block */
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    set_socket_non_blocking(fds[0]);
+
+    /* Fill the send buffer */
+    char big[4096];
+    memset(big, 'x', sizeof(big));
+    for (int i = 0; i < 1000; i++) {
+        ssize_t w = write(fds[0], big, sizeof(big));
+        if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            break;
+    }
+
+    Packet out;
+    memset(&out, 0, sizeof(out));
+    out.type = MSG_CONTENT;
+    out.len = 100;
+    memset(out.u.msg, 'z', 100);
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    int ret = send_packet_nonblock(fds[0], &out);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
+                      (end.tv_nsec - start.tv_nsec) / 1000000;
+
+    ASSERT_EQ(ret, -1);
+    ASSERT_TRUE(elapsed_ms < 100);  /* must not block */
+
+    close(fds[0]);
+    close(fds[1]);
+}
+
 TEST(io, recv_packet_on_half_closed_socket) {
     /* This directly tests the root cause of the busy-loop bug:
      * recv_packet on a socket whose peer has closed must return -1 */


### PR DESCRIPTION
Fixes #47.

## Problem

The session server (`qe -R`) deadlocks when a connected client's terminal disappears. `write_all()` retries `EAGAIN` with `poll(..., -1)` (infinite timeout), blocking the server forever on a single dead client. New connections can never be accepted — reattach hangs indefinitely.

## Fix

### 1. `write_all_timeout()` — bounded poll

Replaces the core of `write_all()` with a `timeout_ms` parameter:
- `-1` = infinite (backward-compatible)
- `0` = pure non-blocking (return `-1` immediately on `EAGAIN`)
- `>0` = wait up to that many milliseconds

Also checks `POLLERR|POLLHUP|POLLNVAL` after poll to detect dead fds. `write_all()` becomes a thin wrapper: `write_all_timeout(fd, buf, len, -1)`.

### 2. `send_packet_nonblock()` — server never blocks on clients

New function using `write_all_timeout(..., 0)`. The server main loop uses this for PTY→client forwarding. If the non-blocking send fails (buffer full / dead client), the client is marked `STATE_DISCONNECTED` and cleaned up — the server continues accepting and serving other clients.

### 3. Client-side write timeout

`write_all(STDOUT_FILENO, ...)` in the client main loop is replaced with `write_all_timeout(STDOUT_FILENO, ..., 5000)`. If the client's terminal is dead, the write times out after 5 seconds and the client disconnects cleanly from the server.

## Tests

6 new tests in `test_session.c`:

| Test | What it verifies |
|------|-----------------|
| `write_all_timeout_basic` | Normal write succeeds with timeout |
| `write_all_timeout_to_closed_pipe` | Returns `-1` on closed socket, doesn't hang |
| `write_all_timeout_returns_on_full_buffer` | **Core #47 test**: returns `-1` within timeout when buffer full |
| `write_all_timeout_zero_means_nonblocking` | `timeout=0` returns immediately |
| `send_packet_nonblock_basic` | Succeeds on writable socket |
| `send_packet_nonblock_full_buffer` | Returns `-1` instantly when buffer full |

All 67 session tests pass.