### PR TITLE
Harden build security: -Werror, banned functions, overflow-safe allocators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - master
 
+# Security: CI jobs cannot write back to the repository
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Build and test (cosmocc)
@@ -20,3 +24,11 @@ jobs:
 
       - name: Build and test
         run: make -j$(nproc) ci
+
+      - name: Check for binary blobs in new source files
+        run: |
+          if git diff origin/master...HEAD --diff-filter=A -- '*.c' '*.h' 2>/dev/null \
+             | grep -P '^\+[A-Za-z0-9+/=]{80,}$'; then
+            echo "ERROR: possible base64 blob detected in new source files"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,23 @@ endif
 
 -include cflags.mk
 
-CFLAGS += -mcosmo -Wno-unused-result
+CFLAGS += -mcosmo
+# Security: strict warnings — zero tolerance (inspired by curl's hardening)
+CFLAGS += -Wall -Wextra -Werror
+CFLAGS += -Wformat=2 -Wformat-security
+CFLAGS += -Wshadow -Wwrite-strings
+CFLAGS += -Wcast-align
+CFLAGS += -Wunused -Wno-unused-parameter -Wno-unused-result
+CFLAGS += -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS += -Wold-style-definition
+CFLAGS += -Wnull-dereference
+CFLAGS += -Wdouble-promotion
+CFLAGS += -Wimplicit-fallthrough
+# Promote these to errors once existing warnings are fixed:
+CFLAGS += -Wno-error=sign-conversion -Wno-error=conversion
+CFLAGS += -Wsign-conversion -Wconversion
+# Runtime buffer overflow detection for libc functions
+CFLAGS += -D_FORTIFY_SOURCE=2
 CFLAGS += -I.
 # Auto-generate .d dependency files so only affected objects rebuild on header changes
 CFLAGS += -MMD -MP
@@ -214,7 +230,11 @@ $(OBJS_DIR)/qe_modules.c: $(SRCS) Makefile tools/gen-modules.sh
 
 $(OBJS_DIR)/charset.o: charset.c wcwidth.c
 $(OBJS_DIR)/charsetjis.o: charsetjis.c charsetjis.def
-$(OBJS_DIR)/modes/stb.o: modes/stb.c modes/stb_image.h
+# stb_image.h is vendored third-party code: relax warnings
+$(OBJS_DIR)/modes/stb.o: modes/stb.c modes/stb_image.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
+	$(echo) CC $(ECHO_CFLAGS) -c $<
+	$(cmd)  mkdir -p $(dir $@)
+	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-error -Wno-double-promotion -Wno-sign-conversion -Wno-conversion -Wno-unused-but-set-variable -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 $(OBJS_DIR)/libunicode.o: libunicode.c libunicode.h libunicode-table.h
 $(OBJS_DIR)/libregexp.o: libregexp.c libregexp.h libregexp-opcode.h
 $(OBJS_DIR)/libqhtml/html_style.o: $(GENDIR)/libqhtml/html_style.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
@@ -231,11 +251,11 @@ $(OBJS_DIR)/libqhtml/css.o: libqhtml/css.c libqhtml/css.h libqhtml/cssid.h
 $(OBJS_DIR)/libqhtml/cssparse.o: libqhtml/cssparse.c libqhtml/css.h libqhtml/cssid.h
 $(OBJS_DIR)/libqhtml/xmlparse.o: libqhtml/xmlparse.c libqhtml/css.h libqhtml/htmlent.h
 
-# Lua amalgamation: compile without QEmacs defines
+# Lua amalgamation: compile without QEmacs defines, relaxed warnings for vendored code
 $(OBJS_DIR)/third_party/lua/lua-amalg.o: third_party/lua/lua-amalg.c third_party/lua/lua-amalg.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC -c $<
 	$(cmd)  mkdir -p $(dir $@)
-	$(cmd)  $(CC) $(CFLAGS) -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 
 $(OBJS_DIR)/%.o: %.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<
@@ -335,6 +355,41 @@ lint:
 	   | grep -v 'write_all_timeout\|qe_write_timeout' \
 	   | grep -v 'session\.c'; then \
 	    echo "ERROR: found write_all() usage — use write_all_timeout/qe_write_timeout with bounded timeout"; \
+	    fail=1; \
+	fi; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi
+	@echo "==> checking for banned function usage in source"
+	@fail=0; \
+	if grep -rn '\bsprintf\s*(' --include='*.c' \
+	   | grep -v 'tests/' | grep -v 'third_party/' | grep -v 'tools/' \
+	   | grep -v 'snprintf\|do_not_use\|vsnprintf'; then \
+	    echo "ERROR: found sprintf() — use snprintf instead"; \
+	    fail=1; \
+	fi; \
+	if grep -rn '\bstrcpy\s*(' --include='*.c' \
+	   | grep -v 'tests/' | grep -v 'third_party/' | grep -v 'tools/' \
+	   | grep -v 'pstrcpy\|do_not_use'; then \
+	    echo "ERROR: found strcpy() — use pstrcpy instead"; \
+	    fail=1; \
+	fi; \
+	if grep -rn '\bstrcat\s*(' --include='*.c' \
+	   | grep -v 'tests/' | grep -v 'third_party/' | grep -v 'tools/' \
+	   | grep -v 'pstrcat\|pstrncat\|do_not_use'; then \
+	    echo "ERROR: found strcat() — use pstrcat instead"; \
+	    fail=1; \
+	fi; \
+	if grep -rn '\batoi\s*(' --include='*.c' \
+	   | grep -v 'tests/' | grep -v 'third_party/' | grep -v 'tools/' \
+	   | grep -v 'qe_atoi'; then \
+	    echo "ERROR: found atoi() — use qe_atoi instead"; \
+	    fail=1; \
+	fi; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi
+	@echo "==> checking for dangerous Unicode (bidi overrides, zero-width chars)"
+	@fail=0; \
+	if grep -rPn '\xe2\x80[\xaa-\xae\x8b-\x8f]|\xe2\x81[\xa6-\xa9]|\xef\xbb\xbf' --include='*.c' --include='*.h' \
+	   | grep -v 'third_party/' | grep -v 'tests/' | grep -v 'tools/'; then \
+	    echo "ERROR: dangerous Unicode (bidi override or zero-width) in source"; \
 	    fail=1; \
 	fi; \
 	if [ "$$fail" -eq 1 ]; then exit 1; fi

--- a/cutils.h
+++ b/cutils.h
@@ -120,11 +120,38 @@ static inline const char *cs8(const u8 *p) {
 #define strstart(str, val, ptr)    qe_strstart(str, val, ptr)
 #define strend(str, val, ptr)      qe_strend(str, val, ptr)
 
-/* make sure neither strncpy not strtok are used */
+/* Ban dangerous C functions — use safe alternatives instead */
 #undef strncpy
-#define strncpy(d,s)      do_not_use_strncpy!!(d,s)
+#define strncpy(d,s)        do_not_use_strncpy__use_pstrncpy!!(d,s)
 #undef strtok
-#define strtok(str,sep)   do_not_use_strtok!!(str,sep)
+#define strtok(str,sep)     do_not_use_strtok!!(str,sep)
+#undef strcpy
+#define strcpy(d,s)         do_not_use_strcpy__use_pstrcpy!!(d,s)
+#undef strcat
+#define strcat(d,s)         do_not_use_strcat__use_pstrcat!!(d,s)
+#undef strncat
+#define strncat(d,s,n)      do_not_use_strncat__use_pstrncat!!(d,s,n)
+#undef sprintf
+#define sprintf(...)        do_not_use_sprintf__use_snprintf!!(__VA_ARGS__)
+#undef gets
+#define gets(s)             do_not_use_gets!!(s)
+
+/* Checked size multiplication — returns 0 on overflow (causes allocation failure) */
+static inline size_t safe_mul(size_t a, size_t b) {
+    if (a != 0 && b > SIZE_MAX / a) return 0;
+    return a * b;
+}
+
+/* Safe integer parsing — returns default_val on NULL, empty, invalid, or overflow */
+static inline int qe_atoi(const char *s, int default_val) {
+    char *end;
+    long v;
+    if (!s || !*s) return default_val;
+    v = strtol(s, &end, 10);
+    if (end == s || *end != '\0') return default_val;
+    if (v < INT_MIN || v > INT_MAX) return default_val;
+    return (int)v;
+}
 
 char *pstrcpy(char *buf, int buf_size, const char *str);
 char *pstrcat(char *buf, int buf_size, const char *s);

--- a/display.c
+++ b/display.c
@@ -502,12 +502,12 @@ QEPicture *qe_create_picture(int width, int height,
 
     ip = qe_mallocz(QEPicture);
     if (ip) {
-        /* align pixmap lines on 64 bit boundaries */
-        unsigned int wb = width * bits + 63 / 64 * 8;
+        /* align pixmap lines on 64 bit (8 byte) boundaries */
+        unsigned int wb = ((width * bits + 63) / 64) * 8;
         ip->width = width;
         ip->height = height;
         ip->format = format;
-        ip->data[0] = qe_malloc_array(unsigned char, wb * height);
+        ip->data[0] = qe_malloc_bytes(safe_mul(wb, height));
         ip->linesize[0] = wb;
     }
     return ip;

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -558,7 +558,7 @@ static char *getentryslink(char *path, int size, const char *filename)
 
 static char *compute_attr(char *atts, mode_t mode)
 {
-    strcpy(atts, "----------");
+    pstrcpy(atts, 11, "----------");
 
     /* File type */
     if (!S_ISREG(mode)) {
@@ -1307,12 +1307,12 @@ static void dired_build_list(DiredState *ds, const char *path)
 
     if (is_directory(ds->path)) {
         pstrcpy(dirname, sizeof dirname, ds->path);
-        strcpy(ds->pattern, "*");
+        pstrcpy(ds->pattern, sizeof(ds->pattern), "*");
     } else {
         get_dirname(dirname, sizeof dirname, ds->path);
         pstrcpy(ds->pattern, sizeof(ds->pattern), get_basename(ds->path));
         if (!is_filepattern(ds->pattern))
-            strcpy(ds->pattern, "*");
+            pstrcpy(ds->pattern, sizeof(ds->pattern), "*");
     }
 
     if (ds->header_lines == 1) {

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -158,15 +158,15 @@ static int get_pty(int *master_fd, int *slave_fd)
             ptydev[len-2] = ttydev[len-2] = *c1;
             for (c2 = ptychar2; *c2; c2++) {
                 ptydev[len-1] = ttydev[len-1] = *c2;
-                int mfd = open(ptydev, O_RDWR);
-                if (mfd >= 0) {
+                int pty_fd = open(ptydev, O_RDWR);
+                if (pty_fd >= 0) {
                     int sfd = open(ttydev, O_RDWR);
                     if (sfd >= 0) {
-                        *master_fd = mfd;
+                        *master_fd = pty_fd;
                         *slave_fd = sfd;
                         return 0;
                     }
-                    close(mfd);
+                    close(pty_fd);
                 }
             }
         }
@@ -287,7 +287,7 @@ static int run_process(ShellState *s,
         setenv("TERM_PROGRAM_VERSION", str_version, 1);
         unsetenv("PAGER");
         vp = getenv("QELEVEL");
-        snprintf(qelevel, sizeof qelevel, "%d", 1 + (vp ? atoi(vp) : 0));
+        snprintf(qelevel, sizeof qelevel, "%d", 1 + qe_atoi(vp, 0));
         setenv("QELEVEL", qelevel, 1);
 
         if (path) {
@@ -332,7 +332,7 @@ static const char *shell_osc_get_string(ShellState *s, int *slen) {
 
 static void qe_term_init(ShellState *s)
 {
-    char *term;
+    const char *term;
 
     s->state = QE_TERM_STATE_NORM;
     /* Should compute def_color from shell default style at display

--- a/plugin.c
+++ b/plugin.c
@@ -8,7 +8,10 @@
  * Uses the Lua amalgamation from whilp/cosmopolitan.
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
 #include "third_party/lua/lua-amalg.h"
+#pragma GCC diagnostic pop
 
 #ifdef QE_MODULE
 /* When compiled as a standalone test, skip qe.h dependencies */
@@ -19,6 +22,16 @@
 #endif
 
 #include <dirent.h>
+
+/* ---- Forward declarations (used by tests) ---- */
+
+lua_State *qe_lua_get_state(void);
+int qe_lua_eval(lua_State *L, const char *code, char *errbuf, int errsize);
+int qe_lua_load_config(lua_State *L, const char *filename,
+                       char *errbuf, int errsize);
+int qe_lua_eval_expression(lua_State *L, const char *code,
+                           char *result, int result_size,
+                           char *errbuf, int errsize);
 
 /* ---- Lua state management ---- */
 
@@ -523,7 +536,8 @@ static void qe_load_lua_plugins_from_dir(lua_State *L, const char *dir)
     while ((de = readdir(d)) != NULL) {
         if (!is_lua_file(de->d_name))
             continue;
-        snprintf(path, sizeof(path), "%s/%s", dir, de->d_name);
+        if ((size_t)snprintf(path, sizeof(path), "%s/%s", dir, de->d_name) >= sizeof(path))
+            continue;  /* path too long, skip */
         if (qe_load_lua_file(L, path) != LUA_OK) {
             /* Log error but continue loading other plugins */
             fprintf(stderr, "qe: error loading plugin %s: %s\n",
@@ -753,7 +767,7 @@ static int plugin_init(QEmacsState *qs)
             char lua_code[1024];
             snprintf(lua_code, sizeof(lua_code),
                      "package.path = '%s/.qe/?.lua;' .. package.path", home);
-            luaL_dostring(qe_L, lua_code);
+            (void)luaL_dostring(qe_L, lua_code);
         }
     }
 

--- a/qe.c
+++ b/qe.c
@@ -2001,7 +2001,7 @@ static void quote_key(void *opaque, int key)
     QEmacsState *qs = s->qs;
     int repeat = qa->argval;
 
-    put_status(s, "");  /* erase "Quote: " message */
+    put_status(s, "%s", "");  /* erase "Quote: " message */
     /* Achtung! this should free the grab data */
     qe_ungrab_keys(qs);
 
@@ -3888,9 +3888,9 @@ void display_close(DisplayState *ds)
 }
 
 void display_init(DisplayState *ds, EditState *e, enum DisplayType do_disp,
-                  int (*cursor_func)(DisplayState *ds,
-                                     int offset1, int offset2, int line_num,
-                                     int x, int y, int w, int h, int hex_mode),
+                  int (*cursor_cb)(DisplayState *ds,
+                                   int offset1, int offset2, int line_num,
+                                   int x, int y, int w, int h, int hex_mode),
                   void *cursor_opaque)
 {
     QEFont *font;
@@ -3899,7 +3899,7 @@ void display_init(DisplayState *ds, EditState *e, enum DisplayType do_disp,
     memset(ds, 0, sizeof(*ds));
     ds->edit_state = e;
     ds->do_disp = do_disp;
-    ds->cursor_func = cursor_func;
+    ds->cursor_func = cursor_cb;
     ds->cursor_opaque = cursor_opaque;
     ds->wrap = e->wrap;
     if (ds->wrap == WRAP_AUTO) {

--- a/qe.h
+++ b/qe.h
@@ -1346,9 +1346,9 @@ enum DisplayType {
 };
 
 void display_init(DisplayState *s, EditState *e, enum DisplayType do_disp,
-                  int (*cursor_func)(DisplayState *,
-                                     int offset1, int offset2, int line_num,
-                                     int x, int y, int w, int h, int hex_mode),
+                  int (*cursor_cb)(DisplayState *,
+                                   int offset1, int offset2, int line_num,
+                                   int x, int y, int w, int h, int hex_mode),
                   void *cursor_opaque);
 void display_close(DisplayState *s);
 void display_bol(DisplayState *s);

--- a/session.c
+++ b/session.c
@@ -314,14 +314,15 @@ int qe_session_get_dir(char *buf, size_t size) {
 }
 
 static int set_socket_path(char *path, size_t size, const char *name) {
-    char dir[200];
+    char dir[108];  /* sized to match sun_path */
     if (name[0] == '/' || name[0] == '.') {
         snprintf(path, size, "%s", name);
         return 0;
     }
     if (qe_session_get_dir(dir, sizeof(dir)) < 0)
         return -1;
-    snprintf(path, size, "%s/%s", dir, name);
+    if ((size_t)snprintf(path, size, "%s/%s", dir, name) >= size)
+        return -1;  /* path truncated */
     return 0;
 }
 
@@ -878,9 +879,12 @@ static int create_session(const char *name, int argc, char **argv) {
             sa.sa_handler = server_sigchld_handler;
             sigaction(SIGCHLD, &sa, NULL);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
             switch (server.pid = forkpty(&server.pty, NULL,
                                          has_term ? &server.term : NULL,
                                          &server.winsize)) {
+#pragma GCC diagnostic pop
             case 0:  /* grandchild: exec qemacs */
                 close(server.socket);
                 close(server_pipe[0]);

--- a/test_display.c
+++ b/test_display.c
@@ -208,10 +208,8 @@ static int test_dpy_init(QEditScreen *s, QEmacsState *qs,
     s->charset = &charset_utf8;
 
     /* Determine screen size from env or defaults */
-    p = getenv("QE_TEST_WIDTH");
-    s->width = p ? atoi(p) : 80;
-    p = getenv("QE_TEST_HEIGHT");
-    s->height = p ? atoi(p) : 24;
+    s->width = qe_atoi(getenv("QE_TEST_WIDTH"), 80);
+    s->height = qe_atoi(getenv("QE_TEST_HEIGHT"), 24);
 
     if (s->width < 10) s->width = 80;
     if (s->height < 3) s->height = 24;
@@ -221,7 +219,7 @@ static int test_dpy_init(QEditScreen *s, QEmacsState *qs,
     /* Set up input fd */
     p = getenv("QE_TEST_INPUT_FD");
     if (p) {
-        ts->input_fd = atoi(p);
+        ts->input_fd = qe_atoi(p, fileno(stdin));
     } else {
         ts->input_fd = fileno(stdin);
     }

--- a/tests/test_cutils.c
+++ b/tests/test_cutils.c
@@ -518,6 +518,49 @@ TEST(osc_get_payload, too_short) {
     ASSERT_EQ(len, 0);
 }
 
+/* ---- safe_mul (integer overflow protection) ---- */
+
+TEST(safe_mul, basic) {
+    ASSERT_EQ(safe_mul(4, 8), 32u);
+    ASSERT_EQ(safe_mul(0, 100), 0u);
+    ASSERT_EQ(safe_mul(100, 0), 0u);
+    ASSERT_EQ(safe_mul(1, 1), 1u);
+}
+
+TEST(safe_mul, overflow_returns_zero) {
+    /* SIZE_MAX * 2 must overflow */
+    ASSERT_EQ(safe_mul(SIZE_MAX, 2), 0u);
+    ASSERT_EQ(safe_mul(2, SIZE_MAX), 0u);
+    /* Large values that overflow when multiplied */
+    ASSERT_EQ(safe_mul(SIZE_MAX / 2 + 1, 2), 0u);
+    ASSERT_EQ(safe_mul(SIZE_MAX, SIZE_MAX), 0u);
+}
+
+TEST(safe_mul, edge_cases) {
+    ASSERT_EQ(safe_mul(SIZE_MAX, 1), SIZE_MAX);
+    ASSERT_EQ(safe_mul(1, SIZE_MAX), SIZE_MAX);
+    ASSERT_EQ(safe_mul(0, 0), 0u);
+}
+
+/* ---- qe_atoi (safe integer parsing) ---- */
+
+TEST(qe_atoi, basic) {
+    ASSERT_EQ(qe_atoi("42", 0), 42);
+    ASSERT_EQ(qe_atoi("-7", 0), -7);
+    ASSERT_EQ(qe_atoi("0", -1), 0);
+}
+
+TEST(qe_atoi, null_and_empty) {
+    ASSERT_EQ(qe_atoi(NULL, 99), 99);
+    ASSERT_EQ(qe_atoi("", 99), 99);
+}
+
+TEST(qe_atoi, invalid_input) {
+    ASSERT_EQ(qe_atoi("abc", -1), -1);
+    ASSERT_EQ(qe_atoi("12abc", -1), -1);
+    ASSERT_EQ(qe_atoi("  42", -1), 42);  /* strtol accepts leading whitespace */
+}
+
 int main(void) {
     return testlib_run_all();
 }

--- a/tty.c
+++ b/tty.c
@@ -395,7 +395,6 @@ static void tty_dpy_invalidate(QEditScreen *s)
     TTYState *ts;
     struct winsize ws;
     int i, count, size;
-    const char *p;
     TTYChar tc;
 
     if (s == NULL)
@@ -404,8 +403,8 @@ static void tty_dpy_invalidate(QEditScreen *s)
     ts = s->priv_data;
 
     /* get screen default values from environment */
-    s->width = (p = getenv("COLUMNS")) != NULL ? atoi(p) : 80;
-    s->height = (p = getenv("LINES")) != NULL ? atoi(p) : 25;
+    s->width = qe_atoi(getenv("COLUMNS"), 80);
+    s->height = qe_atoi(getenv("LINES"), 25);
 
     /* update screen dimensions from pseudo tty ioctl */
     if (ioctl(fileno(s->STDIN), TIOCGWINSZ, &ws) == 0) {

--- a/util.h
+++ b/util.h
@@ -537,13 +537,13 @@ void qe_free(T **pp);
 
 #define qe_malloc(t)            ((t *)qe_malloc_bytes(sizeof(t)))
 #define qe_mallocz(t)           ((t *)qe_mallocz_bytes(sizeof(t)))
-#define qe_malloc_array(t, n)   ((t *)qe_malloc_bytes((n) * sizeof(t)))
-#define qe_mallocz_array(t, n)  ((t *)qe_mallocz_bytes((n) * sizeof(t)))
+/* Overflow-safe array allocators: safe_mul returns 0 on overflow → NULL */
+#define qe_malloc_array(t, n)   ((t *)qe_malloc_bytes(safe_mul((n), sizeof(t))))
+#define qe_mallocz_array(t, n)  ((t *)qe_mallocz_bytes(safe_mul((n), sizeof(t))))
 #define qe_malloc_hack(t, n)    ((t *)qe_malloc_bytes(sizeof(t) + (n)))
 #define qe_mallocz_hack(t, n)   ((t *)qe_mallocz_bytes(sizeof(t) + (n)))
-// XXX: Should use (typeof(**(p)) *) if available
-#define qe_malloc_dup_array(p, n)  (qe_malloc_dup_bytes(p, (n) * sizeof(*(p))))
-#define qe_realloc_array(pp, n)  (qe_realloc_bytes(pp, (n) * sizeof(**(pp))))
+#define qe_malloc_dup_array(p, n)  (qe_malloc_dup_bytes(p, safe_mul((n), sizeof(*(p)))))
+#define qe_realloc_array(pp, n)  (qe_realloc_bytes(pp, safe_mul((n), sizeof(**(pp)))))
 
 #if 1  // to test clang -Weverything
 #define qe_free(pp)    do { void *_1 = (pp), **_2 = _1; (free)(*_2); *_2 = NULL; } while (0)


### PR DESCRIPTION
## Summary

Inspired by curl's ["Don't Trust, Verify"](https://daniel.haxx.se/blog/2026/03/26/dont-trust-verify/) approach, this adds layered compile-time and CI security defenses:

- **`-Werror` + strict warnings**: `-Wall -Wextra -Werror` with 12 additional flags (`-Wformat=2`, `-Wshadow`, `-Wstrict-prototypes`, `-Wmissing-prototypes`, etc.). `-Wconversion`/`-Wsign-conversion` added as non-error warnings with a promotion path. Vendored third-party code (lua-amalg, stb_image) gets relaxed flags.
- **`_FORTIFY_SOURCE=2`**: Runtime buffer overflow detection for libc functions at no perf cost.
- **Banned functions**: Compile-time macro bans for `strcpy`, `strcat`, `sprintf`, `strncat`, `gets` (extending existing `strncpy`/`strtok`/`malloc`/`free`/`realloc` bans). Added `qe_atoi()` safe integer parser replacing all bare `atoi()` calls.
- **Overflow-safe allocators**: Added `safe_mul()` checked multiplication used by all `qe_malloc_array`/`qe_mallocz_array`/`qe_realloc_array` macros. Fixed operator precedence bug in `display.c` picture allocation.
- **Expanded lint**: Grep-based CI checks for banned function usage + dangerous Unicode detection (bidi overrides, zero-width chars).
- **CI hardening**: `permissions: contents: read` (CI cannot write back to repo), base64 blob detection in new source files.
- **New tests**: `safe_mul` overflow tests, `qe_atoi` edge case tests.

## Test plan

- [x] `make` — clean build with zero errors under `-Werror`
- [x] `make test` — all existing + new tests pass
- [x] `make lint` — all lint checks pass (I/O patterns, banned functions, Unicode)
- [ ] CI pipeline passes

https://claude.ai/code/session_01FDyqqhqAoc63qv35vhrLHm