### PR TITLE
Fix Ctrl-A and Ctrl-Q dropping through in shell interactive mode

### DIFF
--- a/modes/shell.c
+++ b/modes/shell.c
@@ -3870,11 +3870,25 @@ void shell_colorize_line(QEColorizeContext *cp,
     }
 }
 
+static void shell_quoted_insert(EditState *e, int argval)
+{
+    ShellState *s = shell_get_state(e, 1);
+
+    if (s && (e->interactive || s->grab_keys)) {
+        qe_term_write(s, "\021", 1); /* Control-Q */
+    } else {
+        do_quoted_insert(e, argval);
+    }
+}
+
 /* shell mode specific commands */
 static const CmdDef shell_commands[] = {
     CMD0( "shell-toggle-input", "C-o",
           "Toggle between shell input and buffer navigation",
           do_shell_toggle_input)
+    CMD2( "shell-quoted-insert", "C-q",
+          "Pass C-q through to PTY in interactive mode, otherwise quoted-insert",
+          shell_quoted_insert, ESi, "p")
     /* XXX: should have shell-execute-line on M-RET */
     CMD2( "shell-enter", "RET, LF",
           "Shell buffer RET key",

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2971,10 +2971,6 @@ static void shell_move_bol(EditState *e)
 {
     ShellState *s = shell_get_state(e, 1);
 
-    /* exit shell interactive mode on home / ^A at start of shell input */
-    if (!s || (e->offset == s->cur_prompt && !s->grab_keys))
-        e->interactive = 0;
-
     if (s && e->interactive) {
         qe_term_write(s, "\001", 1); /* Control-A */
     } else {


### PR DESCRIPTION
## Summary

- Remove the `cur_prompt` guard in `shell_move_bol()` that incorrectly exited interactive mode when pressing Ctrl-A. The heuristic fired for subprocesses (e.g. Claude Code) running inside the shell, dropping interactive mode and swallowing the keystroke instead of passing it to the PTY.
- Add `shell-quoted-insert` bound to `C-q` in shell mode: passes `\021` directly to the PTY when interactive or in grab-keys mode; falls back to normal `quoted-insert` in edit mode.

## Test plan

- [ ] Open `M-x shell`, start an interactive subprocess (e.g. `claude`), verify Ctrl-A reaches the subprocess
- [ ] Verify Ctrl-A at the bash prompt still moves to beginning of line
- [ ] Verify Ctrl-Q sends 0x11 to a subprocess that needs it
- [ ] Verify Ctrl-Q in edit mode (after `C-o`) still invokes quoted-insert normally
- [ ] Use `C-o` to toggle modes explicitly

https://claude.ai/code/session_01WXF2WgRzoJenpw1w6YBcv6