### PR TITLE
Fix -Wsign-conversion and -Wconversion warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,14 @@ $(OBJS_DIR)/modes/stb.o: modes/stb.c modes/stb_image.h Makefile | $(COSMOCC_DIR)
 	$(echo) CC $(ECHO_CFLAGS) -c $<
 	$(cmd)  mkdir -p $(dir $@)
 	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-error -Wno-double-promotion -Wno-sign-conversion -Wno-conversion -Wno-unused-but-set-variable -MT $@ -MF $(@:.o=.d) -o $@ -c $<
-$(OBJS_DIR)/libunicode.o: libunicode.c libunicode.h libunicode-table.h
-$(OBJS_DIR)/libregexp.o: libregexp.c libregexp.h libregexp-opcode.h
+# libunicode and libregexp are vendored QuickJS code: relax warnings
+$(OBJS_DIR)/libunicode.o: libunicode.c libunicode.h libunicode-table.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
+	$(echo) CC $(ECHO_CFLAGS) -c $<
+	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-sign-conversion -Wno-conversion -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+
+$(OBJS_DIR)/libregexp.o: libregexp.c libregexp.h libregexp-opcode.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
+	$(echo) CC $(ECHO_CFLAGS) -c $<
+	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-sign-conversion -Wno-conversion -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 $(OBJS_DIR)/libqhtml/html_style.o: $(GENDIR)/libqhtml/html_style.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<
 	$(cmd)  mkdir -p $(dir $@)
@@ -255,7 +261,7 @@ $(OBJS_DIR)/libqhtml/xmlparse.o: libqhtml/xmlparse.c libqhtml/css.h libqhtml/htm
 $(OBJS_DIR)/third_party/lua/lua-amalg.o: third_party/lua/lua-amalg.c third_party/lua/lua-amalg.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC -c $<
 	$(cmd)  mkdir -p $(dir $@)
-	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -Wno-sign-conversion -Wno-conversion -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 
 $(OBJS_DIR)/%.o: %.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,6 @@ CFLAGS += -Wold-style-definition
 CFLAGS += -Wnull-dereference
 CFLAGS += -Wdouble-promotion
 CFLAGS += -Wimplicit-fallthrough
-# Promote these to errors once existing warnings are fixed:
-CFLAGS += -Wno-error=sign-conversion -Wno-error=conversion
 CFLAGS += -Wsign-conversion -Wconversion
 # Runtime buffer overflow detection for libc functions
 CFLAGS += -D_FORTIFY_SOURCE=2

--- a/buffer.c
+++ b/buffer.c
@@ -65,7 +65,7 @@ static void update_page(Page *p)
 
     /* if the page is read only, copy it */
     if (p->flags & PG_READ_ONLY) {
-        buf = qe_malloc_dup_bytes(p->data, p->size);
+        buf = qe_malloc_dup_bytes(p->data, (size_t)p->size);
         /* XXX: should return an error */
         if (!buf)
             return;
@@ -112,7 +112,7 @@ int eb_read(EditBuffer *b, int offset, void *buf, int size)
         len = p->size - offset;
         if (len > remain)
             len = remain;
-        memcpy(buf, p->data + offset, len);
+        memcpy(buf, p->data + offset, (size_t)len);
         if ((remain -= len) <= 0)
             break;
         buf = (u8*)buf + len;
@@ -152,7 +152,7 @@ int eb_write(EditBuffer *b, int offset, const void *buf, int size)
             if (len > remain)
                 len = remain;
             update_page(p);
-            memcpy(p->data + page_offset, buf, len);
+            memcpy(p->data + page_offset, buf, (size_t)len);
             buf = (const u8*)buf + len;
             if ((remain -= len) <= 0)
                 break;
@@ -181,9 +181,9 @@ static void eb_insert1(EditBuffer *b, int page_index, const u8 *buf, int size)
             update_page(p);
             /* CG: probably faster with qe_malloc + qe_free */
             // XXX: test for failure
-            qe_realloc_bytes(&p->data, p->size + len);
-            memmove(p->data + len, p->data, p->size);
-            memcpy(p->data, buf + size - len, len);
+            qe_realloc_bytes(&p->data, (size_t)(p->size + len));
+            memmove(p->data + len, p->data, (size_t)p->size);
+            memcpy(p->data, buf + size - len, (size_t)len);
             size -= len;
             p->size += len;
         }
@@ -202,7 +202,7 @@ static void eb_insert1(EditBuffer *b, int page_index, const u8 *buf, int size)
             if (len > MAX_PAGE_SIZE)
                 len = MAX_PAGE_SIZE;
             p->size = len;
-            p->data = qe_malloc_dup_bytes(buf, len);
+            p->data = qe_malloc_dup_bytes(buf, (size_t)len);
             p->flags = 0;
             buf += len;
             size -= len;
@@ -233,7 +233,7 @@ static void eb_insert_lowlevel(EditBuffer *b, int offset,
             len = size;
         /* number of bytes to put in next pages */
         len_out = p->size + len - MAX_PAGE_SIZE;
-        page_index = p - b->page_table;
+        page_index = (int)(p - b->page_table);
         if (len_out > 0) {
 #if 1
             /* First try and shift some of these bytes to the previous pages */
@@ -243,8 +243,8 @@ static void eb_insert_lowlevel(EditBuffer *b, int offset,
                 update_page(p);
                 chunk = min_offset(MAX_PAGE_SIZE - p[-1].size, offset);
                 // XXX: test for failure
-                qe_realloc_bytes(&p[-1].data, p[-1].size + chunk);
-                memcpy(p[-1].data + p[-1].size, p->data, chunk);
+                qe_realloc_bytes(&p[-1].data, (size_t)(p[-1].size + chunk));
+                memcpy(p[-1].data + p[-1].size, p->data, (size_t)chunk);
                 p[-1].size += chunk;
                 p->size -= chunk;
                 if (p->size == 0) {
@@ -258,9 +258,9 @@ static void eb_insert_lowlevel(EditBuffer *b, int offset,
                     offset = p->size;
                     goto retry;
                 }
-                memmove(p->data, p->data + chunk, p->size);
+                memmove(p->data, p->data + chunk, (size_t)p->size);
                 // XXX: test for failure
-                qe_realloc_bytes(&p->data, p->size);
+                qe_realloc_bytes(&p->data, (size_t)p->size);
                 offset -= chunk;
                 if (offset == 0 && p[-1].size < MAX_PAGE_SIZE) {
                     /* restart from previous page */
@@ -282,10 +282,10 @@ static void eb_insert_lowlevel(EditBuffer *b, int offset,
             update_page(p);
             p->size += len - len_out;
             // XXX: test for failure
-            qe_realloc_bytes(&p->data, p->size);
+            qe_realloc_bytes(&p->data, (size_t)p->size);
             memmove(p->data + offset + len,
-                    p->data + offset, p->size - (offset + len));
-            memcpy(p->data + offset, buf, len);
+                    p->data + offset, (size_t)(p->size - (offset + len)));
+            memcpy(p->data + offset, buf, (size_t)len);
             buf += len;
             size -= len;
         }
@@ -512,10 +512,10 @@ int eb_delete(EditBuffer *b, int offset, int size)
         } else {
             update_page(p);
             memmove(p->data + offset, p->data + offset + len,
-                    p->size - offset - len);
+                    (size_t)(p->size - offset - len));
             p->size -= len;
             // XXX: test for failure
-            qe_realloc_bytes(&p->data, p->size);
+            qe_realloc_bytes(&p->data, (size_t)p->size);
             offset += len;
             /* XXX: should merge with adjacent pages if size becomes small? */
             if (offset >= p->size) {
@@ -675,7 +675,7 @@ int eb_set_buffer_name(EditBuffer *b, const char *name1)
     EditBuffer *b1;
 
     pstrcpy(name, sizeof(name) - 10, name1);
-    pos = strlen(name);
+    pos = (int)strlen(name);
     if (pos > 0 && name[pos - 1] == '*') {
         pos--;
         prefix = "-";
@@ -687,7 +687,7 @@ int eb_set_buffer_name(EditBuffer *b, const char *name1)
         if (b == b1)
             return 0;
         n++;
-        snprintf(name + pos, sizeof(name) - pos, "%s%d%s", prefix, n, suffix);
+        snprintf(name + pos, sizeof(name) - (size_t)pos, "%s%d%s", prefix, n, suffix);
     }
     /* This is the only place where b->name is modified */
     eb_cache_remove(b);
@@ -908,7 +908,7 @@ void qe_trace_bytes(QEmacsState *qs, const void *buf, int size, int state)
     /* output at end of trace buffer */
     b->offset = b->total_size;
     if (size < 0)
-        size = strlen(buf);
+        size = (int)strlen(buf);
 
     eb_get_pos(b, &line, &col, b->offset);
     flush = state & EB_TRACE_FLUSH;
@@ -955,7 +955,7 @@ void qe_trace_bytes(QEmacsState *qs, const void *buf, int size, int state)
                 col = 9;
             }
             if (p0 < p) {
-                len = min_offset(p - p0, MAX_TRACE_WIDTH - col);
+                len = min_offset((int)(p - p0), MAX_TRACE_WIDTH - col);
                 eb_printf(b, "%.*s", len, p0);
                 p0 += len;
                 col += len;
@@ -1050,7 +1050,7 @@ int eb_create_style_buffer(EditBuffer *b, int flags)
         if (!b->b_styles)
             return -1;
         b->flags |= flags & BF_STYLES;
-        b->style_shift = (((unsigned)flags & BF_STYLES) / BF_STYLE1) - 1;
+        b->style_shift = (int)(((unsigned)flags & BF_STYLES) / BF_STYLE1) - 1;
         b->style_bytes = 1 << b->style_shift;
         eb_set_style(b, 0, LOGOP_INSERT, 0, b->total_size);
         eb_add_callback(b, eb_style_callback, NULL, 0);
@@ -1104,10 +1104,10 @@ void eb_set_style(EditBuffer *b, QETermStyle style, enum LogOperation op,
             } else
             if (b->style_shift == 1) {
                 for (i = 0; i < len >> 1; i++) {
-                    s.buf2[i] = style;
+                    s.buf2[i] = (uint16_t)style;
                 }
             } else {
-                memset(s.buf, style, len);
+                memset(s.buf, (int)style, (size_t)len);
             }
             if (op == LOGOP_WRITE)
                 eb_write(b->b_styles, offset, s.buf, len);
@@ -1182,7 +1182,7 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
         len = lb.size;
         if (lb.op == LOGOP_INSERT)
             len = 0;
-        len += sizeof(LogBuffer) + sizeof(int);
+        len += (int)(sizeof(LogBuffer) + sizeof(int));
         eb_delete(b->log_buffer, 0, len);
         b->log_new_index -= len;
         if (b->log_current > 1)
@@ -1193,11 +1193,11 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
     /* If inserting, try and coalesce log record with previous */
     if (op == LOGOP_INSERT && b->last_log == LOGOP_INSERT
     &&  (size_t)b->log_new_index >= sizeof(lb) + sizeof(int)
-    &&  eb_read(b->log_buffer, b->log_new_index - sizeof(int), &size_trailer,
-                sizeof(int)) == sizeof(int)
+    &&  eb_read(b->log_buffer, b->log_new_index - (int)sizeof(int), &size_trailer,
+                (int)sizeof(int)) == (int)sizeof(int)
     &&  size_trailer == 0
-    &&  eb_read(b->log_buffer, b->log_new_index - sizeof(lb) - sizeof(int), &lb,
-                sizeof(lb)) == sizeof(lb)
+    &&  eb_read(b->log_buffer, b->log_new_index - (int)sizeof(lb) - (int)sizeof(int), &lb,
+                (int)sizeof(lb)) == (int)sizeof(lb)
     &&  lb.op == LOGOP_INSERT
     &&  lb.offset + lb.size == offset) {
         lb.size += size;

--- a/buffer.c
+++ b/buffer.c
@@ -1201,7 +1201,7 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
     &&  lb.op == LOGOP_INSERT
     &&  lb.offset + lb.size == offset) {
         lb.size += size;
-        eb_write(b->log_buffer, b->log_new_index - sizeof(lb) - sizeof(int), &lb, sizeof(lb));
+        eb_write(b->log_buffer, b->log_new_index - (int)sizeof(lb) - (int)sizeof(int), &lb, (int)sizeof(lb));
         return;
     }
 
@@ -1215,9 +1215,9 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
     lb.op = op;
     lb.offset = offset;
     lb.size = size;
-    lb.was_modified = was_modified;
-    eb_write(b->log_buffer, b->log_new_index, &lb, sizeof(lb));
-    b->log_new_index += sizeof(lb);
+    lb.was_modified = (u8)was_modified;
+    eb_write(b->log_buffer, b->log_new_index, &lb, (int)sizeof(lb));
+    b->log_new_index += (int)sizeof(lb);
 
     /* data */
     switch (op) {
@@ -1232,8 +1232,8 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
         break;
     }
     /* trailer */
-    eb_write(b->log_buffer, b->log_new_index, &size_trailer, sizeof(int));
-    b->log_new_index += sizeof(int);
+    eb_write(b->log_buffer, b->log_new_index, &size_trailer, (int)sizeof(int));
+    b->log_new_index += (int)sizeof(int);
 
     b->nb_logs++;
 }
@@ -1279,16 +1279,16 @@ void do_undo(EditState *s)
     }
 
     /* go backward */
-    log_index -= sizeof(int);
-    eb_read(b->log_buffer, log_index, &size_trailer, sizeof(int));
-    log_index -= size_trailer + sizeof(LogBuffer);
+    log_index -= (int)sizeof(int);
+    eb_read(b->log_buffer, log_index, &size_trailer, (int)sizeof(int));
+    log_index -= size_trailer + (int)sizeof(LogBuffer);
 
     /* log_current is 1 + index to have zero as default value */
     b->log_current = log_index + 1;
 
     /* play the log entry */
-    eb_read(b->log_buffer, log_index, &lb, sizeof(LogBuffer));
-    log_index += sizeof(LogBuffer);
+    eb_read(b->log_buffer, log_index, &lb, (int)sizeof(LogBuffer));
+    log_index += (int)sizeof(LogBuffer);
 
     b->last_log = 0;  /* prevent log compression */
 
@@ -1352,23 +1352,23 @@ void do_redo(EditState *s)
 
     /* go forward in undo stack */
     log_index = b->log_current - 1;
-    eb_read(b->log_buffer, log_index, &lb, sizeof(LogBuffer));
-    log_index += sizeof(LogBuffer);
+    eb_read(b->log_buffer, log_index, &lb, (int)sizeof(LogBuffer));
+    log_index += (int)sizeof(LogBuffer);
     if (lb.op != LOGOP_INSERT)
         log_index += lb.size;
-    log_index += sizeof(int);
+    log_index += (int)sizeof(int);
     /* log_current is 1 + index to have zero as default value */
     b->log_current = log_index + 1;
 
     /* go backward from the end and remove undo record */
     log_index = b->log_new_index;
-    log_index -= sizeof(int);
-    eb_read(b->log_buffer, log_index, &size_trailer, sizeof(int));
-    log_index -= size_trailer + sizeof(LogBuffer);
+    log_index -= (int)sizeof(int);
+    eb_read(b->log_buffer, log_index, &size_trailer, (int)sizeof(int));
+    log_index -= size_trailer + (int)sizeof(LogBuffer);
 
     /* play the log entry */
-    eb_read(b->log_buffer, log_index, &lb, sizeof(LogBuffer));
-    log_index += sizeof(LogBuffer);
+    eb_read(b->log_buffer, log_index, &lb, (int)sizeof(LogBuffer));
+    log_index += (int)sizeof(LogBuffer);
 
     switch (lb.op) {
     case LOGOP_WRITE:
@@ -1405,7 +1405,7 @@ void do_redo(EditState *s)
 
     b->modified = lb.was_modified;
 
-    log_index -= sizeof(LogBuffer);
+    log_index -= (int)sizeof(LogBuffer);
     eb_delete(b->log_buffer, log_index, b->log_new_index - log_index);
     b->log_new_index = log_index;
 
@@ -1478,7 +1478,7 @@ char32_t eb_nextc(EditBuffer *b, int offset, int *next_ptr)
             b->charset_state.p = buf;
             /* XXX: incorrect behaviour on ill encoded utf8 sequences */
             ch = b->charset_state.decode_func(&b->charset_state);
-            offset += (b->charset_state.p - buf) - 1;
+            offset += (int)(b->charset_state.p - buf) - 1;
         }
         if (ch == '\r') {
             if (b->eol_type == EOL_DOS) {
@@ -1509,7 +1509,7 @@ QETermStyle eb_get_style(EditBuffer *b, int offset)
         if (b->style_shift == 3) {
             uint64_t style = 0;
             eb_read(b->b_styles, (offset >> b->char_shift) << 3, &style, 8);
-            return style;
+            return (QETermStyle)style;
         } else
         if (b->style_shift == 2) {
             uint32_t style = 0;
@@ -1667,15 +1667,16 @@ char32_t eb_prevc(EditBuffer *b, int offset, int *prev_ptr)
         if (b->charset == &charset_utf8) {
             char_size = 1;
             offset -= 1;
-            ch = eb_read_one_byte(b, offset);
-            if (utf8_is_trailing_byte(ch)) {
+            ch = (char32_t)eb_read_one_byte(b, offset);
+            if (utf8_is_trailing_byte((unsigned char)ch)) {
                 int offset1 = offset;
                 q = buf + sizeof(buf);
                 *--q = '\0';
-                *--q = ch;
-                while (utf8_is_trailing_byte(ch) && offset > 0 && q > buf) {
+                *--q = (u8)ch;
+                while (utf8_is_trailing_byte((unsigned char)ch) && offset > 0 && q > buf) {
                     offset -= 1;
-                    *--q = ch = eb_read_one_byte(b, offset);
+                    ch = (char32_t)eb_read_one_byte(b, offset);
+                    *--q = (u8)ch;
                 }
                 if (ch >= 0xc0) {
                     ch = utf8_decode((const char **)(void *)&q);
@@ -1937,7 +1938,7 @@ int eb_raw_buffer_load1(EditBuffer *b, FILE *f, int offset)
     //put_status(b->qs->active_window, "Loading %s", filename);
     size = inserted = 0;
     for (;;) {
-        len = fread(buf, 1, IOBUF_SIZE, f);
+        len = (int)fread(buf, 1, IOBUF_SIZE, f);
         if (len <= 0) {
             if (ferror(f))
                 return -1;
@@ -1955,7 +1956,7 @@ int eb_raw_buffer_load1(EditBuffer *b, FILE *f, int offset)
 void eb_munmap_buffer(EditBuffer *b)
 {
     if (b->map_address) {
-        munmap(b->map_address, b->map_length);
+        munmap(b->map_address, (size_t)b->map_length);
         b->map_address = NULL;
         b->map_length = 0;
     }
@@ -1972,9 +1973,9 @@ int eb_mmap_buffer(EditBuffer *b, const char *filename)
     fd = open(filename, O_RDONLY);
     if (fd < 0)
         return -1;
-    file_size = lseek(fd, 0, SEEK_END);
+    file_size = (int)lseek(fd, 0, SEEK_END);
     //put_status(b->qs->active_window, "Mapping %s", filename);
-    file_ptr = mmap(NULL, file_size, PROT_READ, MAP_SHARED, fd, 0);
+    file_ptr = mmap(NULL, (size_t)file_size, PROT_READ, MAP_SHARED, fd, 0);
     if ((void*)file_ptr == MAP_FAILED) {
         close(fd);
         return -1;
@@ -2062,7 +2063,7 @@ static int raw_buffer_save(EditBuffer *b, int start, int end,
         if (len > IOBUF_SIZE)
             len = IOBUF_SIZE;
         eb_read(b, start, buf, len);
-        len = write(fd, buf, len);
+        len = (int)write(fd, buf, (size_t)len);
         if (len < 0) {
             close(fd);
             return -1;
@@ -2111,7 +2112,7 @@ int eb_encode_char32(EditBuffer *b, char *buf, char32_t c) {
         *q++ = '?';
     }
     *q = '\0';
-    return q - (u8 *)buf;
+    return (int)(q - (u8 *)buf);
 }
 
 /* Insert unicode character according to buffer encoding */
@@ -2200,7 +2201,7 @@ int eb_insert_char32_buf(EditBuffer *b, int offset, const char32_t *p, int len)
 
 int eb_insert_str(EditBuffer *b, int offset, const char *str)
 {
-    return eb_insert_utf8_buf(b, offset, str, strlen(str));
+    return eb_insert_utf8_buf(b, offset, str, (int)strlen(str));
 }
 
 int eb_match_char32(EditBuffer *b, int offset, char32_t c, int *offsetp)
@@ -2259,7 +2260,7 @@ int eb_putc(EditBuffer *b, char32_t c) {
 }
 
 int eb_puts(EditBuffer *b, const char *s) {
-    return eb_insert_utf8_buf(b, b->offset, s, strlen(s));
+    return eb_insert_utf8_buf(b, b->offset, s, (int)strlen(s));
 }
 
 int eb_vprintf(EditBuffer *b, const char *fmt, va_list ap) {
@@ -2273,14 +2274,14 @@ int eb_vprintf(EditBuffer *b, const char *fmt, va_list ap) {
 #endif
 
     va_copy(ap2, ap);
-    size = sizeof(buf0);
+    size = (int)sizeof(buf0);
     buf = buf0;
-    len = vsnprintf(buf, size, fmt, ap2);
+    len = vsnprintf(buf, (size_t)size, fmt, ap2);
     va_end(ap2);
     if (len >= size) {
         size = len + 1;
-        buf = qe_malloc_bytes(size);
-        vsnprintf(buf, size, fmt, ap);
+        buf = qe_malloc_bytes((size_t)size);
+        vsnprintf(buf, (size_t)size, fmt, ap);
     }
     /* CG: insert buf encoding according to b->charset and b->eol_type.
      * buf may contain \0 characters via the %c modifer.
@@ -2768,7 +2769,7 @@ int eb_save_buffer(EditBuffer *b)
         return ret;
 
     /* set correct file st_mode to old file permissions */
-    chmod(filename, st_mode);
+    chmod(filename, (mode_t)st_mode);
     /* reset log */
     /* CG: should not do this! */
     //eb_free_log_buffer(b);

--- a/charset.c
+++ b/charset.c
@@ -54,7 +54,7 @@ static unsigned short const table_none[256] = { REP256(ESCAPE_CHAR) };
 
 static u8 *encode_raw(qe__unused__ QECharset *charset, u8 *p, char32_t c) {
     if (c <= 0xff) {
-        *p++ = c;
+        *p++ = (u8)c;
         return p;
     } else {
         return NULL;
@@ -122,7 +122,7 @@ static int probe_8859_1(qe__unused__ QECharset *charset, const u8 *buf, int size
 static u8 *encode_8859_1(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
     if (c <= 0xff) {
-        *p++ = c;
+        *p++ = (u8)c;
         return p;
     } else {
         return NULL;
@@ -149,7 +149,7 @@ struct QECharset charset_8859_1 = {
 static u8 *encode_vt100(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
     if (c <= 0xff) {
-        *p++ = c;
+        *p++ = (u8)c;
         return p;
     } else {
         return NULL;
@@ -176,7 +176,7 @@ struct QECharset charset_vt100 = {
 static u8 *encode_7bit(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
     if (c <= 0x7f) {
-        *p++ = c;
+        *p++ = (u8)c;
         return p;
     } else {
         return NULL;
@@ -300,7 +300,7 @@ static void charset_get_pos_utf8(CharsetDecodeState *s, const u8 *buf, int size,
     nl = s->eol_char;
 
     for (;;) {
-        p = memchr(p, nl, p1 - p);
+        p = memchr(p, nl, (size_t)(p1 - p));
         if (!p)
             break;
         p++;
@@ -382,7 +382,7 @@ static int charset_goto_char_utf8(CharsetDecodeState *s,
             break;
         nb_chars++;
     }
-    return buf_ptr - buf;
+    return (int)(buf_ptr - buf);
 }
 
 struct QECharset charset_utf8 = {
@@ -472,8 +472,8 @@ static char32_t decode_ucs2le(CharsetDecodeState *s) {
 static u8 *encode_ucs2le(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
     /* XXX: should handle surrogates */
-    p[0] = c;
-    p[1] = c >> 8;
+    p[0] = (u8)c;
+    p[1] = (u8)(c >> 8);
     return p + 2;
 }
 
@@ -490,7 +490,7 @@ static void charset_get_pos_ucs2(CharsetDecodeState *s, const u8 *buf, int size,
     lp = p = (const uint16_t *)(const void *)buf;
     p1 = p + (size >> 1);
     u.n = 0;
-    u.c[s->charset == &charset_ucs2be] = s->eol_char;
+    u.c[s->charset == &charset_ucs2be] = (char)s->eol_char;
     nl = u.n;
     u.c[s->charset == &charset_ucs2be] = '\n';
     lf = u.n;
@@ -511,7 +511,7 @@ static void charset_get_pos_ucs2(CharsetDecodeState *s, const u8 *buf, int size,
             line++;
         }
     }
-    col = p1 - lp;
+    col = (int)(p1 - lp);
     *line_ptr = line;
     *col_ptr = col;
 }
@@ -526,7 +526,7 @@ static int charset_goto_line_ucs2(CharsetDecodeState *s,
     lp = p = (const uint16_t *)(const void *)buf;
     p1 = p + (size >> 1);
     u.n = 0;
-    u.c[s->charset == &charset_ucs2be] = s->eol_char;
+    u.c[s->charset == &charset_ucs2be] = (char)s->eol_char;
     nl = u.n;
     u.c[s->charset == &charset_ucs2be] = '\n';
     lf = u.n;
@@ -549,7 +549,7 @@ static int charset_goto_line_ucs2(CharsetDecodeState *s,
             }
         }
     }
-    return (const u8 *)lp - buf;
+    return (int)((const u8 *)lp - buf);
 }
 
 static int probe_ucs2be(qe__unused__ QECharset *charset, const u8 *buf, int size)
@@ -603,8 +603,8 @@ static char32_t decode_ucs2be(CharsetDecodeState *s) {
 static u8 *encode_ucs2be(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
     /* XXX: should handle surrogates */
-    p[0] = c >> 8;
-    p[1] = c;
+    p[0] = (u8)(c >> 8);
+    p[1] = (u8)c;
     return p + 2;
 }
 
@@ -665,7 +665,7 @@ static int charset_goto_char_ucs2(CharsetDecodeState *s,
             break;
         nb_chars++;
     }
-    return (const u8*)buf_ptr - buf;
+    return (int)((const u8*)buf_ptr - buf);
 }
 
 struct QECharset charset_ucs2le = {
@@ -746,10 +746,10 @@ static char32_t decode_ucs4le(CharsetDecodeState *s) {
 
 static u8 *encode_ucs4le(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
-    p[0] = c;
-    p[1] = c >> 8;
-    p[2] = c >> 16;
-    p[3] = c >> 24;
+    p[0] = (u8)c;
+    p[1] = (u8)(c >> 8);
+    p[2] = (u8)(c >> 16);
+    p[3] = (u8)(c >> 24);
     return p + 4;
 }
 
@@ -766,7 +766,7 @@ static void charset_get_pos_ucs4(CharsetDecodeState *s, const u8 *buf, int size,
     lp = p = (const uint32_t *)(const void *)buf;
     p1 = p + (size >> 2);
     u.n = 0;
-    u.c[(s->charset == &charset_ucs4be) * 3] = s->eol_char;
+    u.c[(s->charset == &charset_ucs4be) * 3] = (char)s->eol_char;
     nl = u.n;
     u.c[(s->charset == &charset_ucs4be) * 3] = '\n';
     lf = u.n;
@@ -786,7 +786,7 @@ static void charset_get_pos_ucs4(CharsetDecodeState *s, const u8 *buf, int size,
             line++;
         }
     }
-    col = p1 - lp;
+    col = (int)(p1 - lp);
     *line_ptr = line;
     *col_ptr = col;
 }
@@ -801,7 +801,7 @@ static int charset_goto_line_ucs4(CharsetDecodeState *s,
     lp = p = (const uint32_t *)(const void *)buf;
     p1 = p + (size >> 2);
     u.n = 0;
-    u.c[(s->charset == &charset_ucs4be) * 3] = s->eol_char;
+    u.c[(s->charset == &charset_ucs4be) * 3] = (char)s->eol_char;
     nl = u.n;
     u.c[(s->charset == &charset_ucs4be) * 3] = '\n';
     lf = u.n;
@@ -824,7 +824,7 @@ static int charset_goto_line_ucs4(CharsetDecodeState *s,
             }
         }
     }
-    return (const u8 *)lp - buf;
+    return (int)((const u8 *)lp - buf);
 }
 
 static int probe_ucs4be(qe__unused__ QECharset *charset, const u8 *buf, int size)
@@ -877,10 +877,10 @@ static char32_t decode_ucs4be(CharsetDecodeState *s) {
 
 static u8 *encode_ucs4be(qe__unused__ QECharset *charset, u8 *p, char32_t c)
 {
-    p[0] = c >> 24;
-    p[1] = c >> 16;
-    p[2] = c >> 8;
-    p[3] = c;
+    p[0] = (u8)(c >> 24);
+    p[1] = (u8)(c >> 16);
+    p[2] = (u8)(c >> 8);
+    p[3] = (u8)c;
     return p + 4;
 }
 
@@ -939,7 +939,7 @@ static int charset_goto_char_ucs4(CharsetDecodeState *s,
             break;
         nb_chars++;
     }
-    return (const u8*)buf_ptr - buf;
+    return (int)((const u8*)buf_ptr - buf);
 }
 
 struct QECharset charset_ucs4le = {
@@ -997,7 +997,7 @@ void charset_complete(CompleteState *cp, CompleteFunc enumerate) {
             for (q = p = charset->aliases;; q++) {
                 if (*q == '\0' || *q == '|') {
                     if (q > p) {
-                        pstrncpy(name, sizeof(name), p, q - p);
+                        pstrncpy(name, sizeof(name), p, (int)(q - p));
                         enumerate(cp, name, CT_STRX);
                     }
                     if (*q == '\0')
@@ -1457,12 +1457,12 @@ void decode_8bit_init(CharsetDecodeState *s)
 
     table = unconst(unsigned short *)s->table;     /* remove const qualifier */
     for (i = 0; i < charset->min_char; i++)
-        *table++ = i;
+        *table++ = (unsigned short)i;
     n = charset->max_char - charset->min_char + 1;
     for (i = 0; i < n; i++)
         *table++ = charset->private_table[i];
     for (i = charset->max_char + 1; i < 256; i++)
-        *table++ = i;
+        *table++ = (unsigned short)i;
 }
 
 char32_t decode_8bit(CharsetDecodeState *s)
@@ -1490,9 +1490,9 @@ u8 *encode_8bit(QECharset *charset, u8 *q, char32_t c)
         }
         return NULL;
     found:
-        c = charset->min_char + i;
+        c = (char32_t)(charset->min_char + i);
     }
-    *q++ = c;
+    *q++ = (u8)c;
     return q;
 }
 
@@ -1518,7 +1518,7 @@ void charset_get_pos_8bit(CharsetDecodeState *s, const u8 *buf, int size,
     }
 
     for (;;) {
-        p = memchr(p, nl, p1 - p);
+        p = memchr(p, nl, (size_t)(p1 - p));
         if (!p)
             break;
         p++;
@@ -1527,7 +1527,7 @@ void charset_get_pos_8bit(CharsetDecodeState *s, const u8 *buf, int size,
         lp = p;
         line++;
     }
-    col = p1 - lp;
+    col = (int)(p1 - lp);
     *line_ptr = line;
     *col_ptr = col;
 }
@@ -1550,7 +1550,7 @@ int charset_goto_line_8bit(CharsetDecodeState *s,
     }
 
     while (nlines > 0) {
-        p = memchr(p, nl, p1 - p);
+        p = memchr(p, nl, (size_t)(p1 - p));
         if (!p)
             break;
         p++;
@@ -1559,7 +1559,7 @@ int charset_goto_line_8bit(CharsetDecodeState *s,
         lp = p;
         nlines--;
     }
-    return lp - buf;
+    return (int)(lp - buf);
 }
 
 int charset_get_chars_8bit(CharsetDecodeState *s,
@@ -1603,7 +1603,7 @@ int charset_goto_char_8bit(CharsetDecodeState *s,
             break;
         nb_chars++;
     }
-    return buf_ptr - buf;
+    return (int)(buf_ptr - buf);
 }
 
 /********************************************************/

--- a/charsetjis.c
+++ b/charsetjis.c
@@ -87,7 +87,7 @@ static void decode_euc_jp_init(CharsetDecodeState *s)
     int i;
 
     for (i = 0; i < 256; i++)
-        table[i] = i;
+        table[i] = (unsigned short)i;
     table[0x8e] = ESCAPE_CHAR;
     table[0x8f] = ESCAPE_CHAR;
     for (i = 0xa1; i <= 0xfe; i++)
@@ -137,11 +137,11 @@ static char32_t decode_euc_jp_func(CharsetDecodeState *s) {
 
 static unsigned char *encode_euc_jp(qe__unused__ QECharset *s, u8 *q, char32_t c) {
     if (c <= 0x7f) {
-        *q++ = c;
+        *q++ = (u8)c;
     } else
     if (c >= 0xff61 && c <= 0xff9f) {
         *q++ = 0x8e;
-        *q++ = c - 0xff61 + 0xa1;
+        *q++ = (u8)(c - 0xff61 + 0xa1);
     } else {
         /* XXX: do it */
         return NULL;
@@ -174,13 +174,13 @@ static void decode_sjis_init(CharsetDecodeState *s)
     int i;
 
     for (i = 0; i < 256; i++)
-        table[i] = i;
+        table[i] = (unsigned short)i;
     table['\\'] = 0x00a5;
     table[0x80] = '\\';
     for (i = 0x81; i <= 0x9f; i++)
         table[i] = ESCAPE_CHAR;
     for (i = 0xa1; i <= 0xdf; i++)
-        table[i] = i - 0xa1 + 0xff61;
+        table[i] = (unsigned short)(i - 0xa1 + 0xff61);
     for (i = 0xe0; i <= 0xef; i++)
         table[i] = ESCAPE_CHAR;
     for (i = 0xf0; i <= 0xfc; i++)
@@ -205,7 +205,7 @@ static char32_t decode_sjis_func(CharsetDecodeState *s) {
             row = c < 0xa0 ? 0x70 : 0xb0;
             adjust = (c1 < 0x9f);
             col = adjust ? (c1 >= 0x80 ? 32 : 31) : 0x7e;
-            c2 = jis0208_decode(((c - row) << 1) - adjust, c1 - col);
+            c2 = jis0208_decode((int)(((c - row) << 1) - adjust), (int)(c1 - col));
             if (c2) {
                 c = c2;
                 p++;
@@ -218,7 +218,7 @@ static char32_t decode_sjis_func(CharsetDecodeState *s) {
 
 static unsigned char *encode_sjis(qe__unused__ QECharset *s, u8 *q, char32_t c) {
     if (c <= 0x7f) {
-        *q++ = c;
+        *q++ = (u8)c;
     } else {
         /* XXX: do it */
         return NULL;

--- a/color.c
+++ b/color.c
@@ -1109,7 +1109,8 @@ int color_dist(QEColor c1, QEColor c2) {
 /* Convert RGB triplet to a composite color */
 unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *dist)
 {
-    int i, cmin, dmin, d;
+    unsigned int cmin;
+    int i, dmin, d;
 
     color &= 0xFFFFFF;  /* mask off the alpha channel */
 
@@ -1126,7 +1127,7 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
             for (i = 0; i < count; i++) {
                 d = color_dist(color, colors[i]);
                 if (d < dmin) {
-                    cmin = i;
+                    cmin = (unsigned int)i;
                     dmin = d;
                 }
             }
@@ -1161,10 +1162,10 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
                  */
                 // FIXME: use this method for almost greys (eg: #FEFFFE)
                 int grey = r;
-                cmin = scale_grey[grey];
+                cmin = (unsigned int)scale_grey[grey];
                 dmin = color_dist(color, colors[cmin]);
                 if (dmin > 0 && count >= 4096) {
-                    cmin = 0x700 + grey;
+                    cmin = (unsigned int)(0x700 + grey);
                     dmin = 0;
                 }
             } else {
@@ -1175,7 +1176,7 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
                 int r1 = scale_cube6[r];
                 int g1 = scale_cube6[g];
                 int b1 = scale_cube6[b];
-                cmin = 16 + r1 * 36 + g1 * 6 + b1;
+                cmin = (unsigned int)(16 + r1 * 36 + g1 * 6 + b1);
                 dmin = color_dist(color, colors[cmin]);
             }
 #endif
@@ -1216,13 +1217,13 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
                     }
                 }
                 if (d < dmin) {
-                    cmin = i;
+                    cmin = (unsigned int)i;
                     dmin = d;
                 }
                 if (dmin) {
                     for (i = 0; i < nb_custom_colors; i++) {
                         if (custom_colors[i] == color) {
-                            cmin = i + 0x800 + (i & 256) * 6;
+                            cmin = (unsigned int)(i + 0x800 + (i & 256) * 6);
                             dmin = 0;
                             break;
                         }
@@ -1275,7 +1276,7 @@ QEColor qe_unmap_color(int color, int count) {
         }
     }
     /* explicit RGB color with full alpha channel */
-    return color | 0xFF000000;
+    return (QEColor)color | 0xFF000000;
 }
 
 static int add_custom_color(QEColor color) {
@@ -1349,7 +1350,7 @@ int css_define_color(const char *name, const char *value)
     /* Make room: reallocate table in chunks of 8 entries */
     // FIXME: this will reallocate the table even if the color exists
     if (((nb_qe_colors - nb_default_colors) & 7) == 0) {
-        if (!qe_realloc_array(&qe_colors, nb_qe_colors + 8))
+        if (!qe_realloc_array(&qe_colors, (size_t)(nb_qe_colors + 8)))
             return -1;
     }
     /* Check for redefinition of color name */
@@ -1403,20 +1404,20 @@ int css_get_color(QEColor *color_ptr, const char *p)
         /* handle '#' notation */
         p++;
     parse_num:
-        for (len = 0; qe_isxdigit(p[len]); len++)
+        for (len = 0; qe_isxdigit((unsigned char)p[len]); len++)
             continue;
         switch (len) {
         case 3:
             for (i = 0; i < 3; i++) {
-                v = qe_digit_value(*p++);
-                rgba[i] = v | (v << 4);
+                v = qe_digit_value((unsigned char)*p++);
+                rgba[i] = (unsigned char)(v | (v << 4));
             }
             break;
         case 6:
             for (i = 0; i < 3; i++) {
-                v = qe_digit_value(*p++) << 4;
-                v |= qe_digit_value(*p++);
-                rgba[i] = v;
+                v = qe_digit_value((unsigned char)*p++) << 4;
+                v |= qe_digit_value((unsigned char)*p++);
+                rgba[i] = (unsigned char)v;
             }
             break;
         default:
@@ -1424,25 +1425,25 @@ int css_get_color(QEColor *color_ptr, const char *p)
             return -1;
         }
     } else
-    if (*p == 'p' && qe_isdigit(p[1])) {
+    if (*p == 'p' && qe_isdigit((unsigned char)p[1])) {
         QEColor rgb;
-        v = strtol_c(p + 1, &p, 0);
+        v = (int)strtol_c(p + 1, &p, 0);
         rgb = qe_unmap_color(v, 8192);
-        rgba[0] = (rgb >> 16) & 255;
-        rgba[1] = (rgb >> 8) & 255;
-        rgba[2] = (rgb >> 0) & 255;
-        rgba[3] = (rgb >> 24) & 255;
+        rgba[0] = (unsigned char)((rgb >> 16) & 255);
+        rgba[1] = (unsigned char)((rgb >> 8) & 255);
+        rgba[2] = (unsigned char)((rgb >> 0) & 255);
+        rgba[3] = (unsigned char)((rgb >> 24) & 255);
     } else
     if (strstart(p, "rgb:", &p)) {
         /* parse XParseColor syntax */
         for (i = 0; i < 3; i++) {
-            v = strtol_c(q = p, &p, 16);
-            len = p - q;
+            v = (int)strtol_c(q = p, &p, 16);
+            len = (int)(p - q);
             if (len < 2)
                 v |= (v << 4);
             while (len --> 2)
                 v >>= 4;
-            rgba[i] = v | (v << 4);
+            rgba[i] = (unsigned char)(v | (v << 4));
             if (*p == '/')
                 p++;
         }
@@ -1458,12 +1459,12 @@ int css_get_color(QEColor *color_ptr, const char *p)
         for (i = 0; i < n; i++) {
             /* XXX: floats ? */
             qe_skip_spaces(&p);
-            v = strtol_c(p, &p, 0);
+            v = (int)strtol_c(p, &p, 0);
             if (*p == '%') {
                 v = (v * 255) / 100;
                 p++;
             }
-            rgba[i] = v;
+            rgba[i] = (unsigned char)v;
             if (qe_skip_spaces(&p) == ',')
                 p++;
         }
@@ -1520,13 +1521,13 @@ int css_get_enum(const char *str, const char *enum_str) {
     int val, len;
     const char *s, *s0;
 
-    len = strlen(str);
+    len = (int)strlen(str);
     s = enum_str;
     val = 0;
     for (;;) {
         for (s0 = s; *s && *s != ','; s++)
             continue;
-        if ((s - s0) == len && !memcmp(s0, str, len))
+        if ((int)(s - s0) == len && !memcmp(s0, str, (size_t)len))
             return val;
         if (!*s)
             break;

--- a/color.h
+++ b/color.h
@@ -195,7 +195,7 @@ int css_get_font_family(const char *str);
 int css_get_enum(const char *str, const char *enum_str);
 int color_dist(QEColor c1, QEColor c2);
 static inline int color_y(QEColor c) {
-    return 30 * ((c >> 16) & 0xff) + 59 * ((c >> 8) & 0xff) + 11 * (c & 0xff);
+    return (int)(30 * ((c >> 16) & 0xff) + 59 * ((c >> 8) & 0xff) + 11 * (c & 0xff));
 }
 
 typedef struct CSSRect {

--- a/color.h
+++ b/color.h
@@ -40,7 +40,7 @@ typedef int (CSSAbortFunc)(void *);
 #define CSS_MEDIA_ALL     0xffff
 
 typedef uint32_t QEColor;
-#define QEARGB(a,r,g,b)    (((unsigned int)(a) << 24) | ((r) << 16) | ((g) << 8) | (b))
+#define QEARGB(a,r,g,b)    (((unsigned int)(a) << 24) | ((unsigned int)(r) << 16) | ((unsigned int)(g) << 8) | (unsigned int)(b))
 #define QERGB(r,g,b)       QEARGB(0xff, r, g, b)
 #define QERGB25(r,g,b)     QEARGB(1, r, g, b)
 #define COLOR_TRANSPARENT  0

--- a/cutils.c
+++ b/cutils.c
@@ -62,7 +62,7 @@ char *pstrcat(char *buf, int size, const char *s) {
        @note: `strncat` has different semantics and does not check
        for potential overflow of the destination array.
      */
-    int len = strnlen(buf, size);
+    int len = (int)strnlen(buf, (size_t)size);
     if (len < size)
         pstrcpy(buf + len, size - len, s);
     return buf;
@@ -95,7 +95,7 @@ char *pstrncat(char *buf, int size, const char *s, int slen) {
        @return a pointer to the destination array.
        @note truncation cannot be detected reliably.
      */
-    int len = strnlen(buf, size);
+    int len = (int)strnlen(buf, (size_t)size);
     if (len < size)
         pstrncpy(buf + len, size - len, s, slen);
     return buf;
@@ -452,15 +452,15 @@ int __attribute__((format(printf, 2, 3))) dbuf_printf(DynBuf *s, const char *fmt
         return len;
     if (len < (int)sizeof(buf)) {
         /* fast case */
-        return dbuf_put(s, (uint8_t *)buf, len);
+        return dbuf_put(s, (uint8_t *)buf, (size_t)len);
     } else {
-        if (dbuf_realloc(s, s->size + len + 1))
+        if (dbuf_realloc(s, s->size + (size_t)len + 1))
             return -1;
         va_start(ap, fmt);
         vsnprintf((char *)(s->buf + s->size), s->allocated_size - s->size,
                   fmt, ap);
         va_end(ap);
-        s->size += len;
+        s->size += (size_t)len;
     }
     return 0;
 }
@@ -488,34 +488,34 @@ int unicode_to_utf8(uint8_t *buf, unsigned int c) {
     uint8_t *q = buf;
 
     if (c < 0x80) {
-        *q++ = c;
+        *q++ = (uint8_t)c;
     } else {
         if (c < 0x800) {
-            *q++ = (c >> 6) | 0xc0;
+            *q++ = (uint8_t)((c >> 6) | 0xc0);
         } else {
             if (c < 0x10000) {
-                *q++ = (c >> 12) | 0xe0;
+                *q++ = (uint8_t)((c >> 12) | 0xe0);
             } else {
                 if (c < 0x00200000) {
-                    *q++ = (c >> 18) | 0xf0;
+                    *q++ = (uint8_t)((c >> 18) | 0xf0);
                 } else {
                     if (c < 0x04000000) {
-                        *q++ = (c >> 24) | 0xf8;
+                        *q++ = (uint8_t)((c >> 24) | 0xf8);
                     } else if (c < 0x80000000) {
-                        *q++ = (c >> 30) | 0xfc;
-                        *q++ = ((c >> 24) & 0x3f) | 0x80;
+                        *q++ = (uint8_t)((c >> 30) | 0xfc);
+                        *q++ = (uint8_t)(((c >> 24) & 0x3f) | 0x80);
                     } else {
                         return 0;
                     }
-                    *q++ = ((c >> 18) & 0x3f) | 0x80;
+                    *q++ = (uint8_t)(((c >> 18) & 0x3f) | 0x80);
                 }
-                *q++ = ((c >> 12) & 0x3f) | 0x80;
+                *q++ = (uint8_t)(((c >> 12) & 0x3f) | 0x80);
             }
-            *q++ = ((c >> 6) & 0x3f) | 0x80;
+            *q++ = (uint8_t)(((c >> 6) & 0x3f) | 0x80);
         }
-        *q++ = (c & 0x3f) | 0x80;
+        *q++ = (uint8_t)((c & 0x3f) | 0x80);
     }
-    return q - buf;
+    return (int)(q - buf);
 }
 
 int unicode_from_utf8(const uint8_t *p, int max_len, const uint8_t **pp) {

--- a/cutils.h
+++ b/cutils.h
@@ -175,9 +175,9 @@ static inline int strequal(const char *s1, const char *s2) {
  * p1 and p2 should have the same type
  * the macro checks that the types pointed to by p1 and p2 have the same size
  */
-#define blockcmp(p1, p2, n)   memcmp(p1, p2, (n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
-#define blockcpy(p1, p2, n)   memcpy(p1, p2, (n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
-#define blockmove(p1, p2, n) memmove(p1, p2, (n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
+#define blockcmp(p1, p2, n)   memcmp(p1, p2, (size_t)(n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
+#define blockcpy(p1, p2, n)   memcpy(p1, p2, (size_t)(n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
+#define blockmove(p1, p2, n) memmove(p1, p2, (size_t)(n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
 
 size_t get_basename_offset(const char *filename);
 

--- a/cutils.h
+++ b/cutils.h
@@ -386,7 +386,7 @@ static inline int min3_int(int a, int b, int c) {
     return min_int(min_int(a, b), c);
 }
 
-static inline int max_uint(unsigned int a, unsigned int b) {
+static inline unsigned int max_uint(unsigned int a, unsigned int b) {
     /*@API utils
        Compute the maximum value of 2 integers
        @argument `a` an `unsigned int` value
@@ -399,7 +399,7 @@ static inline int max_uint(unsigned int a, unsigned int b) {
         return b;
 }
 
-static inline int min_uint(unsigned int a, unsigned int b) {
+static inline unsigned int min_uint(unsigned int a, unsigned int b) {
     /*@API utils
        Compute the minimum value of 2 integers
        @argument `a` an `unsigned int` value

--- a/display.c
+++ b/display.c
@@ -496,19 +496,19 @@ QEPicture *qe_create_picture(int width, int height,
     QEPicture *ip;
     unsigned int bits;
 
-    bits = qe_picture_format_bits(format);
-    if (bits <= 0)
+    bits = (unsigned int)qe_picture_format_bits(format);
+    if ((int)bits <= 0)
         return NULL;
 
     ip = qe_mallocz(QEPicture);
     if (ip) {
         /* align pixmap lines on 64 bit (8 byte) boundaries */
-        unsigned int wb = ((width * bits + 63) / 64) * 8;
+        unsigned int wb = (((unsigned int)width * bits + 63U) / 64U) * 8U;
         ip->width = width;
         ip->height = height;
         ip->format = format;
-        ip->data[0] = qe_malloc_bytes(safe_mul(wb, height));
-        ip->linesize[0] = wb;
+        ip->data[0] = qe_malloc_bytes(safe_mul(wb, (unsigned int)height));
+        ip->linesize[0] = (int)wb;
     }
     return ip;
 }

--- a/extras.c
+++ b/extras.c
@@ -378,7 +378,7 @@ void do_compare_files(EditState *s, const char *filename, int bflags)
     const char *tail;
     EditState *e;
 
-    pathlen = get_basename_offset(filename);
+    pathlen = (int)get_basename_offset(filename);
     get_default_path(s->b, s->offset, dir, sizeof(dir));
 
     if (strstart(filename, dir, &tail)) {
@@ -397,8 +397,8 @@ void do_compare_files(EditState *s, const char *filename, int bflags)
     } else {
         pstrcpy(buf, sizeof(buf), filename);
         buf[pathlen - 1] = '\0';  /* overwite the path separator */
-        parent_pathlen = get_basename_offset(buf);
-        pstrcpy(buf + parent_pathlen, sizeof(buf) - parent_pathlen, filename + pathlen);
+        parent_pathlen = (int)get_basename_offset(buf);
+        pstrcpy(buf + parent_pathlen, sizeof(buf) - (size_t)parent_pathlen, filename + pathlen);
     }
 
     // XXX: should check for regular file
@@ -826,7 +826,8 @@ static void forward_block(EditState *s, int dir)
     QEColorizeContext cp[1];
     char32_t balance[MAX_LEVEL];
     int use_colors;
-    int line_num, col_num, style, style0, level;
+    int line_num, col_num, level;
+    QETermStyle style, style0;
     int pos;      /* position of the current character on line */
     int len;      /* number of colorized positions */
     int offset;   /* offset of the current character */

--- a/extras.c
+++ b/extras.c
@@ -2297,14 +2297,14 @@ static int tag_print_entry(CompleteState *cp, EditState *s, const char *name) {
 static int tag_get_entry(EditState *s, char *dest, int size, int offset)
 {
     int len = eb_fgets(s->b, dest, size, offset, &offset);
-    int p2 = strcspn(dest, "=[{(,;");
+    int p2 = (int)strcspn(dest, "=[{(,;");
     int p1;
-    while (p2 > 0 && !qe_isalnum_(dest[p2 - 1]))
+    while (p2 > 0 && !qe_isalnum_((u8)dest[p2 - 1]))
         p2--;
     p1 = p2;
-    while (p1 > 0 && (qe_isalnum_(dest[p1 - 1]) || dest[p1 - 1] == '-'))
+    while (p1 > 0 && (qe_isalnum_((u8)dest[p1 - 1]) || dest[p1 - 1] == '-'))
         p1--;
-    memmove(dest, dest + p1, len = p2 - p1);
+    memmove(dest, dest + p1, (size_t)(len = p2 - p1));
     dest[len] = '\0';   /* strip the prototype or trailing newline if any */
     return len;
 }
@@ -2339,10 +2339,10 @@ static void do_find_tag(EditState *s, const char *str) {
 
 static void do_goto_tag(EditState *s) {
     char buf[80];
-    size_t len;
+    int len;
 
     len = qe_get_word(s, buf, sizeof buf, s->offset, NULL);
-    if (len >= sizeof(buf)) {
+    if (len >= (int)sizeof(buf)) {
         put_error(s, "Tag too large");
         return;
     } else

--- a/extras.c
+++ b/extras.c
@@ -2494,8 +2494,8 @@ static int charname_print_entry(CompleteState *cp, EditState *s, const char *nam
     char *p = strchr(name, '\t');
     if (p != NULL) {
         char cbuf[MAX_CHAR_BYTES + 1];
-        char32_t code = strtol(p + 1, NULL, 16);
-        s->b->tab_width = max_int(s->b->tab_width, min_int(60, 2 + (p - name)));
+        char32_t code = (char32_t)strtol(p + 1, NULL, 16);
+        s->b->tab_width = max_int(s->b->tab_width, min_int(60, 2 + (int)(p - name)));
         return eb_printf(s->b, "%s  %s", name,
                          utf8_char32_to_string(cbuf, code));
     } else {
@@ -2512,8 +2512,8 @@ static int charname_get_entry(EditState *s, char *dest, int size, int offset) {
     p = strchr(entry, '\t');
     if (p) {
         p += strspn(p, " \t");
-        len = strcspn(p, " \t\n");
-        return snprintf(dest, size, "0x%.*s", len, p);
+        len = (int)strcspn(p, " \t\n");
+        return snprintf(dest, (size_t)size, "0x%.*s", len, p);
     } else {
         if (size > 0)
             *dest = '\0';
@@ -2543,7 +2543,7 @@ static int eb_print_color(EditBuffer *b, const char *name) {
         if (*name != '#') {
             snprintf(alt_name, sizeof alt_name, "#%06x", color & 0xFFFFFF);
         }
-        bg = qe_map_color(color, xterm_colors, QE_TERM_BG_COLORS, &dist);
+        bg = (int)qe_map_color(color, xterm_colors, QE_TERM_BG_COLORS, &dist);
         fg = (color_y(color) >= 12800) ? 16 : 231;
         style = QE_TERM_COMPOSITE | QE_TERM_MAKE_COLOR(fg, bg);
         style2 = QE_TERM_COMPOSITE | QE_TERM_MAKE_COLOR(bg, 16);
@@ -2593,7 +2593,7 @@ static int eb_print_style(EditBuffer *b, const char *name, int style) {
     b->cur_style = QE_STYLE_FUNCTION;
     len = eb_printf(b, "%s\t", name);
     b->tab_width = max_int(b->tab_width, len + 1);
-    b->cur_style = style;
+    b->cur_style = (QETermStyle)style;
     len += eb_puts(b, "[  Sample  ]");
     b->cur_style = QE_STYLE_DEFAULT;
 

--- a/extras.c
+++ b/extras.c
@@ -1453,7 +1453,7 @@ static int str_get_word7(char *buf, int size, const char *p, const char **pp)
     } else {
         for (; *p != '\0' && *p != ' ' && *p != '/'; p++, len++) {
             if (len + 1 < size) {
-                buf[len] = qe_tolower((u8)*p);
+                buf[len] = (char)qe_tolower((u8)*p);
             }
         }
     }
@@ -1528,7 +1528,7 @@ static int qe_term_get_style_string(char *dest, size_t size, QEStyleDef *stp)
     char buf[16];
     const char *p;
 
-    buf_init(out, dest, size);
+    buf_init(out, dest, (int)size);
 #if 0
     if (stp->attr & QE_TERM_BOLD)
         buf_printf(out, " %s", "bold");
@@ -1577,7 +1577,7 @@ static void do_set_style_color(EditState *e, const char *stylestr, const char *v
     /* accept "fgcolor", "[fgcolor]/bgcolor", "fgcolor on bgcolor" */
     p = value + strcspn(value, " /");
     if (p > value) {
-        pstrncpy(buf, sizeof buf, value, p - value);
+        pstrncpy(buf, sizeof buf, value, (int)(p - value));
         if (css_get_color(&stp->fg_color, buf)) {
             put_error(e, "Unknown fgcolor '%s'", buf);
             return;
@@ -1656,7 +1656,7 @@ static void do_set_region_style(EditState *s, const char *str)
         put_error(s, "Invalid style '%s'", str);
         return;
     }
-    style = st - qe_styles;
+    style = (QETermStyle)(st - qe_styles);
 
     offset = s->b->mark;
     size = s->offset - offset;
@@ -1821,7 +1821,7 @@ static void do_describe_buffer(EditState *s, int argval)
             col += eb_printf(b1, "   %*d  ", count_width, count[i]);
             if (i > 0 && i < 0x7f) {
                 char cbuf[8];
-                byte_quote(cbuf, sizeof cbuf, i);
+                byte_quote(cbuf, sizeof cbuf, (unsigned char)i);
                 col += eb_printf(b1, "'%s'", cbuf);
             } else {
                 col += eb_printf(b1, "0x%02x", (unsigned)i);
@@ -1937,7 +1937,7 @@ static void do_describe_window(EditState *s, int argval)
                 pos = eb_printf(b1, "\n%*s   ", w, "");
             len = snprintf(buf, sizeof buf, "%d", from);
             if (i > from + 1)
-                len += snprintf(buf + len, sizeof(buf) - len, "..%d", i - 1);
+                len += snprintf(buf + len, sizeof(buf) - (size_t)len, "..%d", i - 1);
             pos += eb_printf(b1, " %s: 0x%*x,", buf, w1, bits);
         }
         eb_printf(b1, " }\n");
@@ -2176,7 +2176,7 @@ static int eb_sort_span(EditBuffer *b, int *pp1, int *pp2, int cur_offset, int f
                     pos = pos1;
                 break;
             }
-            chunk_array[i].c[j] = c;
+            chunk_array[i].c[j] = (unsigned short)c;
         }
         chunk_array[i].start = offset;
         chunk_array[i].offset = pos - offset;
@@ -2199,7 +2199,7 @@ static int eb_sort_span(EditBuffer *b, int *pp1, int *pp2, int cur_offset, int f
     for (ctx.total_cmp = 0; i > 0; i >>= 1) {
         ctx.total_cmp += lines;
     }
-    qe_qsort_r(chunk_array, lines, sizeof(*chunk_array), &ctx, chunk_cmp);
+    qe_qsort_r(chunk_array, (size_t)lines, sizeof(*chunk_array), &ctx, chunk_cmp);
 
     b1 = qe_new_buffer(b->qs, "*sorted*", BF_SYSTEM | (b->flags & BF_STYLES));
     if (!b1)

--- a/indic.c
+++ b/indic.c
@@ -128,7 +128,7 @@ int devanagari_log2vis(char32_t *str, unsigned int *ctog, int len) {
     for (i = 0; i < len; i++) {
         c = buf[i];
         if (c != 0) {
-            ctog[i] = j;
+            ctog[i] = (unsigned int)j;
             str[j++] = c;
         } else {
             /* zero: associate it to previous char */
@@ -136,7 +136,7 @@ int devanagari_log2vis(char32_t *str, unsigned int *ctog, int len) {
             k = j - 1;
             if (k < 0)
                 k = 0;
-            ctog[i] = k;
+            ctog[i] = (unsigned int)k;
         }
     }
     return j;

--- a/kmap.c
+++ b/kmap.c
@@ -93,10 +93,10 @@ static int kmap_input(int *match_buf, int match_buf_size,
             if (c < 0x1e) {
                 if (flag) {
                     /* extra output glyphs */
-                    olen = c;
+                    olen = (int)c;
                 } else {
                     /* delta */
-                    last_outputc += c;
+                    last_outputc = last_outputc + (int)c;
                 }
                 break;
             } else
@@ -191,16 +191,16 @@ int qe_load_input_methods(QEmacsState *qs, const char *filename)
     lseek(fd, 0, SEEK_SET);
 
 #ifdef CONFIG_MMAP
-    input_method_map = mmap(NULL, file_size, PROT_READ, MAP_SHARED, fd, 0);
+    input_method_map = mmap(NULL, (size_t)file_size, PROT_READ, MAP_SHARED, fd, 0);
     if (input_method_map != (void*)MAP_FAILED) {
         file_ptr = input_method_map;
-        input_method_size = file_size;
+        input_method_size = (size_t)file_size;
     }
 #endif
     if (!file_ptr) {
         file_ptr = input_method_ptr = qe_malloc_array(char, file_size);
         if (input_method_ptr == NULL
-        ||  read(fd, input_method_ptr, file_size) != file_size) {
+        ||  read(fd, input_method_ptr, (size_t)file_size) != file_size) {
             goto fail;
         }
     }

--- a/lang/arm.c
+++ b/lang/arm.c
@@ -135,10 +135,10 @@ static void arm_asm_colorize_line(QEColorizeContext *cp,
             if (qe_isalpha_(c)) {
             opcode:
                 klen = 0;
-                keyword[klen++] = qe_tolower(c);
+                keyword[klen++] = (char)qe_tolower(c);
                 for (; qe_isalnum_(str[i]) || str[i] == '.'; i++) {
                     if (klen < countof(keyword) - 1)
-                        keyword[klen++] = qe_tolower(str[i]);
+                        keyword[klen++] = (char)qe_tolower(str[i]);
                 }
                 keyword[klen] = '\0';
                 if (str[i] == ':') {
@@ -354,7 +354,7 @@ static int intel_hex_mode_probe(ModeDef *syn, ModeProbeData *pd)
 
     if (match_extension(pd->filename, syn->extensions) && *p == ':') {
         for (i = 1; i < 11; i++) {
-            if (!qe_isxdigit(p[i]))
+            if (!qe_isxdigit((u8)p[i]))
                 return 1;
         }
         return 70;

--- a/lang/asm.c
+++ b/lang/asm.c
@@ -113,10 +113,10 @@ static void asm_colorize_line(QEColorizeContext *cp,
             /* parse identifiers and keywords */
             if (qe_isalpha_(c) || qe_findchar("@.$%?", c)) {
                 len = 0;
-                keyword[len++] = qe_tolower(c);
+                keyword[len++] = (char)qe_tolower(c);
                 for (; qe_isalnum_(str[i]) || qe_findchar("@$%?", str[i]); i++) {
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = qe_tolower(str[i]);
+                        keyword[len++] = (char)qe_tolower(str[i]);
                 }
                 keyword[len] = '\0';
                 if (++wn == 1) {
@@ -124,7 +124,7 @@ static void asm_colorize_line(QEColorizeContext *cp,
                         SET_STYLE(sbuf, start, i, ASM_STYLE_PREPROCESS);
                         i = cp_skip_blanks(str, i, n);
                         start = i;
-                        colstate = str[i++];  /* end of comment character */
+                        colstate = (int)str[i++];  /* end of comment character */
                         /* skip characters upto and including separator */
                     in_comment:
                         while (i < n) {

--- a/lang/ats.c
+++ b/lang/ats.c
@@ -183,14 +183,14 @@ static void ats_colorize_line(QEColorizeContext *cp,
             /* parse identifiers and keywords */
             if (qe_isalpha_(c) || c == '$') {
                 len = 0;
-                keyword[len++] = qe_tolower(c);
+                keyword[len++] = (char)qe_tolower(c);
                 for (; qe_isalnum_(str[i]); i++) {
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = qe_tolower(str[i]);
+                        keyword[len++] = (char)qe_tolower(str[i]);
                 }
                 if (str[i] == '!') {
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = str[i];
+                        keyword[len++] = (char)str[i];
                     i++;
                 }
                 keyword[len] = '\0';

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -128,13 +128,13 @@ int get_c_identifier(char *dest, int size, char32_t c,
     for (;; i++) {
         if (c < 128) {
             if (pos + 1 < size) {
-                dest[pos++] = c;
+                dest[pos++] = (char)c;
             }
         } else {
             char buf[6];
             int len = utf8_encode(buf, c);
             if (pos + len < size) {
-                memcpy(dest + pos, buf, len);
+                memcpy(dest + pos, buf, (size_t)len);
                 pos += len;
             } else {
                 size = pos + 1;
@@ -211,7 +211,8 @@ static void c_colorize_line(QEColorizeContext *cp,
                             QETermStyle *sbuf, ModeDef *syn)
 {
     int i = 0, start, i1, i2, indent, level;
-    int style, style0, style1, type_decl, tag;
+    QETermStyle style, style0, style1;
+    int type_decl, tag;
     char32_t c, delim;
     char kbuf[64];
     int mode_flags = syn->colorize_flags;
@@ -827,7 +828,8 @@ static int c_line_has_label(EditState *s, const char32_t *buf, int len,
                             const QETermStyle *sbuf)
 {
     char kbuf[64];
-    int i, style;
+    int i;
+    QETermStyle style;
 
     i = cp_skip_blanks(buf, 0, len);
 
@@ -865,7 +867,8 @@ void c_indent_line(EditState *s, int offset0)
 {
     QEColorizeContext cp[1];
     int offset, offset1, offsetl, pos, line_num, col_num;
-    int i, eoi_found, len, pos1, lpos, style, line_num1, state;
+    int i, eoi_found, len, pos1, lpos, line_num1, state;
+    QETermStyle style;
     int off, found_comma, has_else;
     char32_t c;
     //int found_semi = 0;
@@ -938,7 +941,7 @@ void c_indent_line(EditState *s, int offset0)
                 if (stack_ptr == 0) {
                     q = kbuf;
                     while (q < kbuf + countof(kbuf) - 1 && off0 <= off1) {
-                        *q++ = cp->buf[off0++];
+                        *q++ = (char)cp->buf[off0++];
                     }
                     *q = '\0';
 
@@ -1266,7 +1269,7 @@ static void c_forward_conditional(EditState *s, int dir)
         sharp = 0;
         for (p = cp->buf; *p; p++) {
             char32_t c = *p;
-            int style = cp->sbuf[p - cp->buf];
+            QETermStyle style = cp->sbuf[p - cp->buf];
             if (qe_isblank(c))
                 continue;
             if (c == '#' && style == C_STYLE_PREPROCESS)
@@ -1342,7 +1345,7 @@ static void do_c_list_conditionals(EditState *s)
         sharp = 0;
         for (p = cp->buf; *p; p++) {
             char32_t c = *p;
-            int style = cp->sbuf[p - cp->buf];
+            QETermStyle style = cp->sbuf[p - cp->buf];
             if (qe_isblank(c))
                 continue;
             if (c == '#' && style == C_STYLE_PREPROCESS)
@@ -1652,7 +1655,7 @@ static int objc_mode_probe(ModeDef *mode, ModeProbeData *mp)
          */
         const char *q;
         for (q = p;; q++) {
-            if ((*q == '@' && qe_isalpha(q[1]))
+            if ((*q == '@' && qe_isalpha((u8)(unsigned char)q[1]))
             ||  (*q == '#' && strstart(p, "#import", NULL))) {
                 return 85;
             }
@@ -1785,13 +1788,13 @@ static int get_js_identifier(char *dest, int size, char32_t c,
     for (;; i++) {
         if (c < 128) {
             if (pos + 1 < size) {
-                dest[pos++] = c;
+                dest[pos++] = (char)c;
             }
         } else {
             char buf[6];
             int len = utf8_encode(buf, c);
             if (pos + len < size) {
-                memcpy(dest + pos, buf, len);
+                memcpy(dest + pos, buf, (size_t)len);
                 pos += len;
             } else {
                 size = pos + 1;
@@ -1813,7 +1816,8 @@ static void js_colorize_line(QEColorizeContext *cp,
                              QETermStyle *sbuf, ModeDef *syn)
 {
     int i = 0, start, i1, indent;
-    int style, tag, level;
+    QETermStyle style;
+    int tag, level;
     char32_t c, delim;
     char kbuf[64];
     int mode_flags = syn->colorize_flags;
@@ -3319,9 +3323,9 @@ static int pawn_mode_probe(ModeDef *mode, ModeProbeData *p)
             "forward" NUL "new" NUL "main()" NUL
             NUL;
         const char *pref;
-        const char *cp = cs8(p->buf);
+        const char *cp = cs8((const u8 *)p->buf);
 
-        while (qe_isspace(*cp))
+        while (qe_isspace((u8)(unsigned char)*cp))
             cp++;
         for (pref = pawn_checks; *pref; pref += strlen(pref) + 1) {
             if (strstart(cp, pref, NULL))
@@ -3648,7 +3652,8 @@ static void salmon_colorize_line(QEColorizeContext *cp,
                                  QETermStyle *sbuf, ModeDef *syn)
 {
     int i = 0, start, i1;
-    int style, tag, level;
+    QETermStyle style;
+    int tag, level;
     char32_t c, delim;
     char kbuf[64];
     int mode_flags = syn->colorize_flags;
@@ -3971,7 +3976,7 @@ static int cp_match_keywords(const char32_t *str, int n, int start, const char *
     int i = start;
     size_t j = 0;
     for (;;) {
-        unsigned char cc = s[j++];
+        unsigned char cc = (unsigned char)s[j++];
         if (cc == '|' || cc == '\0') {
             if (i == n || !qe_isalnum_(str[i])) {
                 *end = i;
@@ -3991,7 +3996,7 @@ static int cp_match_keywords(const char32_t *str, int n, int start, const char *
                     continue;
             }
             for (;;) {
-                cc = s[j++];
+                cc = (unsigned char)s[j++];
                 if (cc == '\0')
                     return 0;
                 if (cc == '|')
@@ -4007,7 +4012,8 @@ static void ppl_colorize_line(QEColorizeContext *cp,
                               QETermStyle *sbuf, ModeDef *syn)
 {
     int i = 0, start, i1;
-    int indent = 0, style, level, type_decl;
+    int indent = 0, level, type_decl;
+    QETermStyle style;
     char32_t c, delim, last;
     char kbuf[64];
     int state = cp->colorize_state;
@@ -4412,7 +4418,8 @@ static void c3_colorize_line(QEColorizeContext *cp,
                              QETermStyle *sbuf, ModeDef *syn)
 {
     int i = 0, start, i1, i2, indent;
-    int style, level, tag;
+    QETermStyle style;
+    int level, tag;
     char32_t c, delim;
     char kbuf[64];
     int state = cp->colorize_state;

--- a/lang/cobol.c
+++ b/lang/cobol.c
@@ -193,13 +193,13 @@ static void cobol_colorize_line(QEColorizeContext *cp,
             if (qe_isalnum_(c)) {
                 /* parse identifiers and keywords */
                 len = 0;
-                keyword[len++] = qe_tolower(c);
+                keyword[len++] = (char)qe_tolower(c);
                 for (; i < n; i++) {
                     char32_t c1 = str[i];
                     if (!qe_isalnum_(c1) && !qe_findchar("-$", c1))
                         break;
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = qe_tolower(c1);
+                        keyword[len++] = (char)qe_tolower(c1);
                 }
                 keyword[len] = '\0';
                 if (strfind(syn->keywords, keyword)) {

--- a/lang/crystal.c
+++ b/lang/crystal.c
@@ -88,11 +88,11 @@ static int crystal_get_name(char *buf, int size, const char32_t *str) {
 
     for (len = 0, j = i; qe_isalnum_(str[j]); j++) {
         if (len < size - 1)
-            buf[len++] = str[j];
+            buf[len++] = (char)str[j];
     }
     if (str[j] == '?' || str[j] == '!') {
         if (len < size - 1)
-            buf[len++] = str[j];
+            buf[len++] = (char)str[j];
         j++;
     }
     if (len < size) {
@@ -119,9 +119,9 @@ static void crystal_colorize_line(QEColorizeContext *cp,
             i = indent;
         }
         if (qe_isalpha_(str[i])) {
-            int sig = str[i++] % 61;
+            int sig = (int)str[i++] % 61;
             for (; qe_isalnum_(str[i]); i++) {
-                sig = ((sig << 6) + str[i]) % 61;
+                sig = (int)(((sig << 6) + (int)str[i]) % 61);
             }
             i = cp_skip_blanks(str, i, n);
             if (i == n && (state & IN_CRYSTAL_HD_SIG) == (sig & IN_CRYSTAL_HD_SIG))
@@ -351,17 +351,17 @@ static void crystal_colorize_line(QEColorizeContext *cp,
                 if ((str[j] == '\'' || str[j] == '\"')
                 &&  qe_isalpha_(str[j + 1])) {
                     sep = str[j++];
-                    sig = str[j++] % 61;
+                    sig = (int)str[j++] % 61;
                     for (; qe_isalnum_(str[j]); j++) {
-                        sig = ((sig << 6) + str[j]) % 61;
+                        sig = (int)(((sig << 6) + (int)str[j]) % 61);
                     }
                     if (str[j++] != sep)
                         break;
                 } else
                 if (qe_isalpha_(str[j])) {
-                    sig = str[j++] % 61;
+                    sig = (int)str[j++] % 61;
                     for (; qe_isalnum_(str[j]); j++) {
-                        sig = ((sig << 6) + str[j]) % 61;
+                        sig = (int)(((sig << 6) + (int)str[j]) % 61);
                     }
                 }
                 if (sig) {

--- a/lang/csv.c
+++ b/lang/csv.c
@@ -164,7 +164,7 @@ static void csv_colorize_line(QEColorizeContext *cp,
             }
             break;
         }
-        sep = CSV_SEP[colstate & CSV_STATE_SEP];
+        sep = (u8)CSV_SEP[colstate & CSV_STATE_SEP];
         start = i = 0;
         while (i < n) {
             c = str[i++];
@@ -183,7 +183,7 @@ static void csv_colorize_line(QEColorizeContext *cp,
         i = 0;
     }
 
-    sep = CSV_SEP[colstate & CSV_STATE_SEP];
+    sep = (char32_t)(unsigned char)CSV_SEP[colstate & CSV_STATE_SEP];
     if (sep == ';')
         dot = ',';
 

--- a/lang/elixir.c
+++ b/lang/elixir.c
@@ -103,7 +103,7 @@ static void elixir_colorize_line(QEColorizeContext *cp,
                         }
                     }
                 parse_regex:
-                    sep = elixir_delim2[state & 15];
+                    sep = (char32_t)(unsigned char)elixir_delim2[state & 15];
                     /* parse regular expression */
                     while (i < n) {
                         if ((c = str[i++]) == '\\') {
@@ -143,7 +143,7 @@ static void elixir_colorize_line(QEColorizeContext *cp,
                 i += 2;
             }
         parse_string:
-            sep = elixir_delim2[state & 15];
+            sep = (char32_t)(unsigned char)elixir_delim2[state & 15];
             style = (state & IN_ELIXIR_TRIPLE) ?
                 ELIXIR_STYLE_HEREDOC : ELIXIR_STYLE_STRING;
             while (i < n) {
@@ -244,15 +244,15 @@ static void elixir_colorize_line(QEColorizeContext *cp,
             if (qe_isalpha_(c)) {
         has_alpha:
                 klen = 0;
-                kbuf[klen++] = c;
+                kbuf[klen++] = (char)(unsigned char)c;
                 for (; qe_isalnum_(c = str[i]); i++) {
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = c;
+                        kbuf[klen++] = (char)(unsigned char)c;
                 }
                 if (c == '!' || c == '?') {
                     i++;
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = c;
+                        kbuf[klen++] = (char)(unsigned char)c;
                 }
                 kbuf[klen] = '\0';
 

--- a/lang/elm.c
+++ b/lang/elm.c
@@ -187,7 +187,7 @@ static void elm_colorize_line(QEColorizeContext *cp,
                 for (klen = 0, i--; qe_isalnum_(str[i]) || str[i] == '\''; i++) {
                     haslower |= qe_islower(str[i]);
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = str[i];
+                        kbuf[klen++] = (char)str[i];
                 }
                 kbuf[klen] = '\0';
 

--- a/lang/emf.c
+++ b/lang/emf.c
@@ -98,10 +98,10 @@ static void emf_colorize_line(QEColorizeContext *cp,
         /* parse identifiers and keywords */
         if (c == '$' || c == '!' || c == '#' || qe_isalpha_(c)) {
             len = 0;
-            keyword[len++] = c;
+            keyword[len++] = (char)c;
             for (; qe_isalnum_(str[i]) || str[i] == '-'; i++) {
                 if (len < countof(keyword) - 1)
-                    keyword[len++] = str[i];
+                    keyword[len++] = (char)str[i];
             }
             keyword[len] = '\0';
             if (c == '$' || c == '#') {

--- a/lang/erlang.c
+++ b/lang/erlang.c
@@ -181,9 +181,9 @@ static void erlang_colorize_line(QEColorizeContext *cp,
         if (qe_isdigit(c)) {
             /* parse numbers */
             style = ERLANG_STYLE_INTEGER;
-            base = c - '0';
+            base = (int)(c - '0');
             while (qe_isdigit(str[i])) {
-                base = base * 10 + str[i++] - '0';
+                base = base * 10 + (int)(str[i++] - '0');
             }
             if (base >= 2 && base <= 36 && str[i] == '#') {
                 for (i += 1; qe_digit_value(str[i]) < base; i++)
@@ -214,10 +214,10 @@ static void erlang_colorize_line(QEColorizeContext *cp,
         if (qe_isalpha_(c) || c == '@') {
             /* parse an Erlang atom or identifier */
             len = 0;
-            keyword[len++] = c;
+            keyword[len++] = (char)c;
             for (; qe_isalnum_(str[i]) || str[i] == '@'; i++) {
                 if (len < countof(keyword) - 1)
-                    keyword[len++] = str[i];
+                    keyword[len++] = (char)str[i];
             }
             keyword[len] = '\0';
             if (start && str[start - 1] == '-'
@@ -233,7 +233,7 @@ static void erlang_colorize_line(QEColorizeContext *cp,
             if (check_fcall(str, i)) {
                 style = ERLANG_STYLE_FUNCTION;
             } else
-            if (qe_islower(keyword[0])) {
+            if (qe_islower((u8)keyword[0])) {
                 style = ERLANG_STYLE_ATOM;
             } else {
                 style = ERLANG_STYLE_IDENTIFIER;

--- a/lang/forth.c
+++ b/lang/forth.c
@@ -117,7 +117,7 @@ static int ff_match_number(const char *str, int *pnum)
     int i = 0, base = 10, digit;
     char32_t c;
     int year = -1, month = -1;
-    long long num = 0, stash = 0;
+    int num = 0, stash = 0;
 
     if (str[i] == '-') {
         i++;
@@ -170,13 +170,13 @@ static int ff_match_number(const char *str, int *pnum)
             continue;
         default:
             if (c >= '0' && c <= '9')
-                digit = (int)c - '0';
+                digit = (int)(c - '0');
             else
             if (c >= 'a' && c <= 'z')
-                digit = (int)c - 'a' + 10;
+                digit = (int)(c - 'a') + 10;
             else
             if (c >= 'A' && c <= 'Z')
-                digit = (int)c - 'A' + 10;
+                digit = (int)(c - 'A') + 10;
             else
                 digit = 255;
             if (digit >= base)
@@ -265,7 +265,7 @@ static void ff_colorize_line(QEColorizeContext *cp,
         word[len++] = (char)c;
         for (; i < n && !qe_isblank(str[i]); i++) {
             if (len < countof(word) - 1)
-                word[len++] = str[i];
+                word[len++] = (char)str[i];
         }
         word[len] = '\0';
         if (strequal("EOF", word) || strequal("EOF`", word)) {

--- a/lang/forth.c
+++ b/lang/forth.c
@@ -125,7 +125,7 @@ static int ff_match_number(const char *str, int *pnum)
             return 0;
     }
 
-    for (; (c = str[i]) != '\0'; i++) {
+    for (; (c = (char32_t)(unsigned char)str[i]) != '\0'; i++) {
         switch (c) {
         case '\'':
             continue;
@@ -139,7 +139,7 @@ static int ff_match_number(const char *str, int *pnum)
             base = 2;
             continue;
         case '#':
-            base = num;
+            base = (int)num;
             num = 0;
             continue;
         case ':':
@@ -152,7 +152,7 @@ static int ff_match_number(const char *str, int *pnum)
             if (i == 0)
                 break;
             if (year >= 0 && month >= 0) {
-                num = ff_convert_date(year, month, num);
+                num = ff_convert_date(year, month, (int)num);
                 num = 0;
                 year = month = -1;
             }
@@ -163,20 +163,20 @@ static int ff_match_number(const char *str, int *pnum)
             if (i == 0)
                 break;
             if (year < 0)
-                year = num;
+                year = (int)num;
             else
-                month = num;
+                month = (int)num;
             num = 0;
             continue;
         default:
             if (c >= '0' && c <= '9')
-                digit = c - '0';
+                digit = (int)c - '0';
             else
             if (c >= 'a' && c <= 'z')
-                digit = c - 'a' + 10;
+                digit = (int)c - 'a' + 10;
             else
             if (c >= 'A' && c <= 'Z')
-                digit = c - 'A' + 10;
+                digit = (int)c - 'A' + 10;
             else
                 digit = 255;
             if (digit >= base)
@@ -187,13 +187,13 @@ static int ff_match_number(const char *str, int *pnum)
         break;
     }
     if (year >= 0 && month >= 0) {
-        stash = ff_convert_date(year, month, num);
+        stash = ff_convert_date(year, month, (int)num);
         num = 0;
     }
     num += stash;
     if (i > 0 && str[i] == '\0') {
         if (pnum)
-            *pnum = (*str == '-') ? -num : num;
+            *pnum = (int)((*str == '-') ? -num : num);
         return i;
     }
     return 0;
@@ -262,7 +262,7 @@ static void ff_colorize_line(QEColorizeContext *cp,
         }
         /* scan for space and determine word type */
         len = 0;
-        word[len++] = c;
+        word[len++] = (char)c;
         for (; i < n && !qe_isblank(str[i]); i++) {
             if (len < countof(word) - 1)
                 word[len++] = str[i];
@@ -290,7 +290,7 @@ static void ff_colorize_line(QEColorizeContext *cp,
             }
         }
         numlen = len;
-        if (numlen > 1 && qe_findchar("|&^+-*/%~,", word[numlen - 1]))
+        if (numlen > 1 && qe_findchar("|&^+-*/%~,", (char32_t)(unsigned char)word[numlen - 1]))
             word[--numlen] = '\0';
         if (ff_match_number(word, &num) == numlen) {
             SET_STYLE(sbuf, start, start + numlen, FF_STYLE_NUMBER);

--- a/lang/fortran.c
+++ b/lang/fortran.c
@@ -133,13 +133,13 @@ static void fortran_colorize_line(QEColorizeContext *cp,
         /* parse identifiers and keywords */
         if (qe_isalpha_(c) || (c == '.' && qe_isalpha(str[i]))) {
             len = 0;
-            keyword[len++] = qe_tolower(c);
+            keyword[len++] = (char)qe_tolower(c);
             for (; qe_isalnum_(str[i]); i++) {
                 if (len < countof(keyword) - 1)
-                    keyword[len++] = qe_tolower(str[i]);
+                    keyword[len++] = (char)qe_tolower(str[i]);
             }
             if (c == '.' && str[i] == '.' && len < countof(keyword) - 1)
-                keyword[len++] = str[i++];
+                keyword[len++] = (char)str[i++];
             keyword[len] = '\0';
 
             if (strfind(syn->keywords, keyword)

--- a/lang/groovy.c
+++ b/lang/groovy.c
@@ -208,13 +208,13 @@ static int java_scan_number(const char32_t *str0, int flavor)
 
 done:
     if (!qe_isalnum_(*str)) {
-        return str - str0;
+        return (int)(str - str0);
     }
 
 error:
     while (qe_isalnum_(*str))
         str++;
-    return -(str - str0);
+    return -(int)(str - str0);
 }
 
 static void groovy_colorize_line(QEColorizeContext *cp,
@@ -397,11 +397,11 @@ static void groovy_colorize_line(QEColorizeContext *cp,
             hasname:
                 haslower = 0;
                 klen = 0;
-                kbuf[klen++] = c;
+                kbuf[klen++] = (char)c;
                 for (; qe_isalnum_(str[i]) || qe_is_groovy_letter(str[i]); i++) {
                     haslower |= qe_islower(str[i]);
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = str[i];
+                        kbuf[klen++] = (char)str[i];
                 }
                 kbuf[klen] = '\0';
 

--- a/lang/haskell.c
+++ b/lang/haskell.c
@@ -180,7 +180,7 @@ static void haskell_colorize_line(QEColorizeContext *cp,
             if (qe_isalpha_(c)) {
                 for (klen = 0, i--; qe_isalnum_(str[i]) || str[i] == '\''; i++) {
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = str[i];
+                        kbuf[klen++] = (char)str[i];
                 }
                 kbuf[klen] = '\0';
 

--- a/lang/htmlsrc.c
+++ b/lang/htmlsrc.c
@@ -57,7 +57,7 @@ static int get_html_entity(const char32_t *p) {
     if (c == ';') {
         p++;
     }
-    return p - p_start;
+    return (int)(p - p_start);
 }
 
 /* colorization states */
@@ -349,13 +349,13 @@ static void htmlsrc_colorize_line(QEColorizeContext *cp,
 
 static int html_tagcmp(const char *s1, const char *s2) {
     while (*s2) {
-        u8 uc1 = *s1++;
-        u8 uc2 = *s2++;
-        int d = uc2 - qe_toupper(uc1);
+        u8 uc1 = (u8)(unsigned char)*s1++;
+        u8 uc2 = (u8)(unsigned char)*s2++;
+        int d = (int)uc2 - (int)qe_toupper(uc1);
         if (d)
             return d;
     }
-    if (qe_isalnum_(*s1))
+    if (qe_isalnum_((char32_t)(unsigned char)*s1))
         return -1;
     return 0;
 }

--- a/lang/inifile.c
+++ b/lang/inifile.c
@@ -123,7 +123,7 @@ static int ini_mode_probe(ModeDef *mode, ModeProbeData *pd)
     while (p < p_end) {
         /* skip comments */
         if (*p == ';' || *p == '#') {
-            p = memchr(p, '\n', p_end - p);
+            p = memchr(p, '\n', (size_t)(p_end - p));
             if (!p)
                 return 1;
         }

--- a/lang/julia.c
+++ b/lang/julia.c
@@ -152,7 +152,7 @@ static int julia_get_number(const char32_t *p)
     } else {
         p -= 1;
     }
-    return p - p0;
+    return (int)(p - p0);
 }
 
 static void julia_colorize_line(QEColorizeContext *cp,

--- a/lang/lisp.c
+++ b/lang/lisp.c
@@ -200,32 +200,32 @@ static int lisp_is_number(const char *str)
     int i;
 
     if (*str == 'b' && str[1]) {
-        for (str++; qe_isbindigit(*str); str++)
+        for (str++; qe_isbindigit((char32_t)(unsigned char)*str); str++)
             continue;
     } else
     if (*str == 'o' && str[1]) {
-        for (str++; qe_isoctdigit(*str); str++)
+        for (str++; qe_isoctdigit((char32_t)(unsigned char)*str); str++)
             continue;
     } else
     if (*str == 'x' && str[1]) {
-        for (str++; qe_isxdigit(*str); str++)
+        for (str++; qe_isxdigit((char32_t)(unsigned char)*str); str++)
             continue;
     } else {
         if ((*str == '-' || *str == 'd') && str[1])
             str++;
-        if (qe_isdigit(*str)) {
-            for (; qe_isdigit(*str); str++)
+        if (qe_isdigit((char32_t)(unsigned char)*str)) {
+            for (; qe_isdigit((char32_t)(unsigned char)*str); str++)
                 continue;
             if (*str == '.') {
-                for (str++; qe_isdigit(*str); str++)
+                for (str++; qe_isdigit((char32_t)(unsigned char)*str); str++)
                     continue;
             }
-            if (qe_tolower(*str) == 'e') {
+            if (qe_tolower((char32_t)(unsigned char)*str) == 'e') {
                 i = 1;
                 if (str[i] == '+' || str[i] == '-')
                     i++;
-                if (qe_isdigit(str[i])) {
-                    for (str += i + 1; qe_isdigit(*str); str++)
+                if (qe_isdigit((char32_t)(unsigned char)str[i])) {
+                    for (str += i + 1; qe_isdigit((char32_t)(unsigned char)*str); str++)
                         continue;
                 }
             }

--- a/lang/lua.c
+++ b/lang/lua.c
@@ -185,7 +185,7 @@ static void lua_colorize_line(QEColorizeContext *cp,
                 }
                 if (syn->types
                 &&  (strfind(syn->types, kbuf)
-                ||   (qe_isupper(c) && qe_islower(kbuf[1])))) {
+                ||   (qe_isupper(c) && qe_islower((char32_t)(unsigned char)kbuf[1])))) {
                     SET_STYLE(sbuf, start, i, LUA_STYLE_TYPE);
                     continue;
                 }

--- a/lang/magpie.c
+++ b/lang/magpie.c
@@ -177,7 +177,7 @@ static void magpie_colorize_line(QEColorizeContext *cp,
                     style = MAGPIE_STYLE_FUNCTION;
                     break;
                 }
-                if (qe_isupper(kbuf[0]) && (start == 0 || str[start-1] != '.')) {
+                if (qe_isupper((u8)kbuf[0]) && (start == 0 || str[start-1] != '.')) {
                     /* Types are capitalized */
                     style = MAGPIE_STYLE_TYPE;
                     break;

--- a/lang/ocaml.c
+++ b/lang/ocaml.c
@@ -211,10 +211,10 @@ static void ocaml_colorize_line(QEColorizeContext *cp,
         /* parse identifiers and keywords */
         if (qe_isalpha_(c)) {
             len = 0;
-            keyword[len++] = c;
+            keyword[len++] = (char)c;
             for (; qe_isalnum_(str[i]) || str[i] == '\''; i++) {
                 if (len < countof(keyword) - 1)
-                    keyword[len++] = str[i];
+                    keyword[len++] = (char)str[i];
             }
             keyword[len] = '\0';
             if (strfind(syn->types, keyword)) {

--- a/lang/perl.c
+++ b/lang/perl.c
@@ -157,7 +157,7 @@ static void perl_colorize_line(QEColorizeContext *cp,
 
     if (colstate & (IN_PERL_STRING1 | IN_PERL_STRING2)) {
         delim = (colstate & IN_PERL_STRING1) ? '\'' : '\"';
-        i = perl_string(str, delim, start, n);
+        i = perl_string(str, (char32_t)delim, start, n);
         if (i < n) {
             i++;
             colstate &= ~(IN_PERL_STRING1 | IN_PERL_STRING2);
@@ -172,7 +172,7 @@ static void perl_colorize_line(QEColorizeContext *cp,
     }
     if (colstate & IN_PERL_HEREDOC) {
         i = n;
-        if (n == perl_eos_len && !umemcmp(perl_eos, str, n)) {
+        if (n == perl_eos_len && !umemcmp(perl_eos, str, (size_t)n)) {
             colstate &= ~IN_PERL_HEREDOC;
             SET_STYLE(sbuf, start, i, PERL_STYLE_KEYWORD);
         } else {
@@ -257,7 +257,7 @@ static void perl_colorize_line(QEColorizeContext *cp,
                 }
                 if (s2 > s1) {
                     perl_eos_len = min_int((int)(s2 - s1), countof(perl_eos) - 1);
-                    umemcpy(perl_eos, str + s1, perl_eos_len);
+                    umemcpy(perl_eos, str + s1, (size_t)perl_eos_len);
                     perl_eos[perl_eos_len] = '\0';
                     colstate |= IN_PERL_HEREDOC;
                 }
@@ -286,10 +286,10 @@ static void perl_colorize_line(QEColorizeContext *cp,
         case '\'':
         case '`':
         case '"':
-            delim = c;
+            delim = (int)c;
         string:
             /* parse string const */
-            s1 = perl_string(str, delim, i, n);
+            s1 = perl_string(str, (char32_t)delim, i, n);
             if (s1 >= n) {
                 if (c == '\'') {
                     colstate |= IN_PERL_STRING1;

--- a/lang/python.c
+++ b/lang/python.c
@@ -162,7 +162,7 @@ static void python_colorize_line(QEColorizeContext *cp,
             /* XXX: should test for regular expression in PYTHON_RAPYDSCRIPT flavor */
             if (str[i] != '/' && mode_flags == PYTHON_RAPYDSCRIPT) {
                 /* XXX: should use more context to tell regex from divide */
-                int prev = ' ';
+                char32_t prev = ' ';
                 for (i1 = start; i1 > 0; ) {
                     prev = str[--i1];
                     if (!qe_isblank(prev))

--- a/lang/rebol.c
+++ b/lang/rebol.c
@@ -228,27 +228,27 @@ static void rebol_colorize_line(QEColorizeContext *cp,
 
             /* parse words */
             klen = 0;
-            keyword[klen++] = qe_tolower(c);
+            keyword[klen++] = (char)qe_tolower(c);
             for (; i < n; i++) {
                 if (qe_findchar(" \t;()[]\"", str[i]))
                     break;
                 if (klen < countof(keyword) - 1)
-                    keyword[klen++] = qe_tolower(str[i]);
+                    keyword[klen++] = (char)qe_tolower(str[i]);
             }
             keyword[klen] = '\0';
             if (qe_isdigit(c) || c == '+' || c == '-') {
                 /* check numbers */
                 int dots = 0;
                 for (k = 1; k < klen; k++) {
-                    if (qe_match2(keyword[k], '.', ',')) {
+                    if (qe_match2((char32_t)(unsigned char)keyword[k], '.', ',')) {
                         dots++;
                     } else
                     if (keyword[k] == 'e') {
-                        if (qe_match2(keyword[k + 1], '+', '-'))
+                        if (qe_match2((char32_t)(unsigned char)keyword[k + 1], '+', '-'))
                             k++;
                     } else
-                    if (!qe_match2(keyword[k], '\'', '%')
-                    &&  !qe_isdigit(keyword[k]))
+                    if (!qe_match2((char32_t)(unsigned char)keyword[k], '\'', '%')
+                    &&  !qe_isdigit((char32_t)(unsigned char)keyword[k]))
                         break;
                 }
                 if (k == klen && dots <= 1) {

--- a/lang/rlang.c
+++ b/lang/rlang.c
@@ -141,11 +141,11 @@ static void r_colorize_line(QEColorizeContext *cp,
             /* parse identifiers and keywords */
             if (qe_isalpha_(c) || c == '.') {
                 len = 0;
-                keyword[len++] = (c < 0xFF) ? c : 0xFF;
+                keyword[len++] = (char)((c < 0xFF) ? c : 0xFF);
                 for (; i < n; i++) {
                     if (qe_isalnum_(str[i]) || str[i] == '.') {
                         if (len < countof(keyword) - 1)
-                            keyword[len++] = (str[i] < 0xFF) ? str[i] : 0xFF;
+                            keyword[len++] = (char)((str[i] < 0xFF) ? str[i] : 0xFF);
                     } else {
                         break;
                     }

--- a/lang/ruby.c
+++ b/lang/ruby.c
@@ -78,11 +78,11 @@ static int ruby_get_name(char *buf, int size, const char32_t *str) {
 
     for (len = 0, j = i; qe_isalnum_(str[j]); j++) {
         if (len < size - 1)
-            buf[len++] = str[j];
+            buf[len++] = (char)str[j];
     }
     if (str[j] == '?' || str[j] == '!') {
         if (len < size - 1)
-            buf[len++] = str[j];
+            buf[len++] = (char)str[j];
         j++;
     }
     if (len < size) {
@@ -109,9 +109,9 @@ static void ruby_colorize_line(QEColorizeContext *cp,
             i = indent;
         }
         if (qe_isalpha_(str[i])) {
-            int sig = str[i++] % 61;
+            int sig = (int)str[i++] % 61;
             for (; qe_isalnum_(str[i]); i++) {
-                sig = ((sig << 6) + str[i]) % 61;
+                sig = (int)(((sig << 6) + (int)str[i]) % 61);
             }
             i = cp_skip_blanks(str, i, n);
             if (i == n && (state & IN_RUBY_HD_SIG) == (sig & IN_RUBY_HD_SIG))
@@ -347,17 +347,17 @@ static void ruby_colorize_line(QEColorizeContext *cp,
                 if ((str[j] == '\'' || str[j] == '\"')
                 &&  qe_isalpha_(str[j + 1])) {
                     sep = str[j++];
-                    sig = str[j++] % 61;
+                    sig = (int)str[j++] % 61;
                     for (; qe_isalnum_(str[j]); j++) {
-                        sig = ((sig << 6) + str[j]) % 61;
+                        sig = (int)(((sig << 6) + (int)str[j]) % 61);
                     }
                     if (str[j++] != sep)
                         break;
                 } else
                 if (qe_isalpha_(str[j])) {
-                    sig = str[j++] % 61;
+                    sig = (int)str[j++] % 61;
                     for (; qe_isalnum_(str[j]); j++) {
-                        sig = ((sig << 6) + str[j]) % 61;
+                        sig = (int)(((sig << 6) + (int)str[j]) % 61);
                     }
                 }
                 if (sig) {

--- a/lang/rye.c
+++ b/lang/rye.c
@@ -118,7 +118,7 @@ static int get_rye_identifier(char *dest, int size, char32_t c,
     for (;; j++) {
         if (c < 128) {
             if (pos < size - 1) {
-                dest[pos++] = c;
+                dest[pos++] = (char)c;
             }
         } else {
             char buf[6];

--- a/lang/scad.c
+++ b/lang/scad.c
@@ -134,7 +134,7 @@ static void scad_colorize_line(QEColorizeContext *cp,
             if (qe_isalnum_(c) || c == '$') {
                 isnum = qe_isdigit(c);
                 len = 0;
-                keyword[len++] = c;
+                keyword[len++] = (char)c;
                 for (; qe_isalnum_(str[i]) || str[i] == '.'; i++) {
                     if (str[i] == '.') {
                         if (!isnum)
@@ -144,7 +144,7 @@ static void scad_colorize_line(QEColorizeContext *cp,
                         isnum = 0;
                     }
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = str[i];
+                        keyword[len++] = (char)str[i];
                 }
                 keyword[len] = '\0';
                 if (isnum) {

--- a/lang/script.c
+++ b/lang/script.c
@@ -53,7 +53,7 @@ static int shell_script_get_var(char *buf, int buf_size,
 
     while (j < n && qe_isalnum_(c = str[j])) {
         if (i < buf_size - 1) {
-            buf[i++] = c;
+            buf[i++] = (char)c;
         }
         j++;
     }

--- a/lang/sharp.c
+++ b/lang/sharp.c
@@ -92,7 +92,7 @@ static int sharp_mode_probe(ModeDef *mode, ModeProbeData *pd)
     ||  stristart(pd->filename, ".clang-format", NULL))
         return 70;
 
-    while (qe_isspace(*p))
+    while (qe_isspace((char32_t)(unsigned char)*p))
         p++;
 
     if (*p == '#') {

--- a/lang/smalltalk.c
+++ b/lang/smalltalk.c
@@ -107,11 +107,11 @@ static void smalltalk_colorize_line(QEColorizeContext *cp,
             if (qe_isalpha(c)) {
                 /* parse identifiers and keywords */
                 len = 0;
-                keyword[len++] = c;
+                keyword[len++] = (char)c;
                 /* should allow other chars: .+/\*~<>@%|&? */
                 for (; i < n && qe_isalnum(str[i]); i++) {
                     if (len < countof(keyword) - 1)
-                        keyword[len++] = str[i];
+                        keyword[len++] = (char)str[i];
                 }
                 keyword[len] = '\0';
                 if (strfind(syn->keywords, keyword))
@@ -128,9 +128,9 @@ static void smalltalk_colorize_line(QEColorizeContext *cp,
                 int value = 0;
 
                 while (qe_isdigit(str[i])) {
-                    value = value * 10 + str[i++] - '0';
+                    value = value * 10 + (int)(str[i++] - '0');
                 }
-                if (qe_findchar("rR", str[i]) && qe_inrange(value, 2, 36)) {
+                if (qe_findchar("rR", str[i]) && qe_inrange((char32_t)value, 2, 36)) {
                     i++;
                     while (qe_digit_value(str[i]) < value)
                         i++;
@@ -173,7 +173,7 @@ static int smalltalk_mode_probe(ModeDef *mode, ModeProbeData *pd)
             return 51;
     }
 
-    while (qe_isspace(*p))
+    while (qe_isspace((char32_t)(unsigned char)*p))
         p++;
 
     if (*p == '!') {

--- a/lang/swift.c
+++ b/lang/swift.c
@@ -126,7 +126,7 @@ static int swift_parse_identifier(char *dest, int size, char32_t c, const char32
         buf_putc_utf8(out, p[i]);
     }
     if (p[i] == '`' && dest[0] == '`')
-        buf_put_byte(out, p[i++]);
+        buf_put_byte(out, (unsigned char)p[i++]);
 
     return i;
 }

--- a/lang/tcl.c
+++ b/lang/tcl.c
@@ -92,12 +92,12 @@ static int tcl_get_word(char *dest, int size, char32_t c,
     for (j = i;; j++) {
         if (pos + 1 < size) {
             /* c is assumed to be an ASCII character */
-            dest[pos++] = c < 0x80 ? c : 0xFF;
+            dest[pos++] = (char)(c < 0x80 ? c : 0xFF);
         }
         if (j >= n)
             break;
         c = str[j];
-        if (c < 0x80 && strchr(stop, c))
+        if (c < 0x80 && strchr(stop, (int)c))
             break;
     }
     if (pos < size) {

--- a/lang/txl.c
+++ b/lang/txl.c
@@ -121,11 +121,11 @@ static void txl_colorize_line(QEColorizeContext *cp,
             /* parse identifiers and keywords */
             if (qe_isalpha_(c)) {
                 klen = 0;
-                keyword[klen++] = qe_tolower(c);
+                keyword[klen++] = (char)qe_tolower(c);
                 for (; i < n; i++) {
                     if (qe_isalnum_(str[i])) {
                         if (klen < countof(keyword) - 1)
-                            keyword[klen++] = qe_tolower(str[i]);
+                            keyword[klen++] = (char)qe_tolower(str[i]);
                     } else {
                         if (qe_findchar("$&!@%#", str[i]))
                             i++;

--- a/lang/vimscript.c
+++ b/lang/vimscript.c
@@ -83,7 +83,7 @@ static int is_vim_keyword(const char32_t *str, int from, int to,
         c = str[from + i];
         if (c >= 0x80)
             return 0;
-        keyword[i] = c;
+        keyword[i] = (char)c;
     }
     keyword[len] = '\0';
 
@@ -94,13 +94,13 @@ static int is_vim_keyword(const char32_t *str, int from, int to,
              i++) {
             continue;
         }
-        if (i <= len && !memcmp(p, keyword, i)) {
+        if (i <= len && !memcmp(p, keyword, (size_t)i)) {
             if (i == len)
                 return 1;
-            if (p[i] == '[' && !memcmp(p + i + 1, keyword + i, len - i))
+            if (p[i] == '[' && !memcmp(p + i + 1, keyword + i, (size_t)(len - i)))
                 return 1;
         }
-        for (p += i; *p != '\0' && (c = *p++) != ' ' && c != '|';)
+        for (p += i; *p != '\0' && (c = (char32_t)(unsigned char)*p++) != ' ' && c != '|';)
             continue;
     }
     return 0;

--- a/lang/virgil.c
+++ b/lang/virgil.c
@@ -208,13 +208,13 @@ static int virgil_scan_number(const char32_t *str0, int flavor) {
 
 done:
     if (!qe_isalnum_(*str)) {
-        return str - str0;
+        return (int)(str - str0);
     }
 
 error:
     while (qe_isalnum_(*str))
         str++;
-    return -(str - str0);
+    return -(int)(str - str0);
 }
 
 static void virgil_colorize_line(QEColorizeContext *cp,
@@ -397,11 +397,11 @@ static void virgil_colorize_line(QEColorizeContext *cp,
             hasname:
                 haslower = 0;
                 klen = 0;
-                kbuf[klen++] = c;
+                kbuf[klen++] = (char)c;
                 for (; qe_isalnum_(str[i]) || qe_is_virgil_letter(str[i]); i++) {
                     haslower |= qe_islower(str[i]);
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = str[i];
+                        kbuf[klen++] = (char)str[i];
                 }
                 kbuf[klen] = '\0';
 

--- a/lang/wolfram.c
+++ b/lang/wolfram.c
@@ -171,7 +171,7 @@ static void wolfram_colorize_line(QEColorizeContext *cp,
             if (qe_isdigit(c)) {
                 int value = 0;
                 while (qe_isdigit(str[i])) {
-                    value = value * 10 + str[i++] - '0';
+                    value = value * 10 + (int)(str[i++] - '0');
                 }
                 if (str[i] == '^' && str[i + 1] == '^' && value < 36) {
                     i += 2;

--- a/libqhtml/css.c
+++ b/libqhtml/css.c
@@ -223,8 +223,8 @@ typedef char32_t (*NextCharFunc)(CSSBox *box, int *offset);
 static char32_t eb_nextc1(CSSBox *box, int *offset_ptr)
 {
     struct EditBuffer *b = box->content_data;
-    int offset, offset1, ch1;
-    char32_t ch;
+    int offset, offset1;
+    char32_t ch, ch1;
     char name[16], *q;
 
     offset = *offset_ptr;
@@ -237,17 +237,18 @@ static char32_t eb_nextc1(CSSBox *box, int *offset_ptr)
             ch1 = eb_nextc(b, offset, &offset);
             if (qe_isspace(ch1) || ch1 == ';')
                 break;
-            *q++ = ch1;
+            *q++ = (char)ch1;
             if (q >= name + sizeof(name) - 1)
                 break;
         }
         *q = '\0';
-        ch1 = find_entity(name);
-        if (ch1 >= 0) {
-            ch = ch1;
-        } else {
+        { int _ent = find_entity(name);
+          if (_ent >= 0) {
+            ch = (char32_t)_ent;
+          } else {
             /* entity not found: roll back */
             offset = offset1;
+          }
         }
     }
     *offset_ptr = offset;
@@ -267,7 +268,7 @@ static char32_t str_nextc(CSSBox *box, int *offset_ptr)
     } else {
         ptr++;
     }
-    *offset_ptr = ptr - str;
+    *offset_ptr = (int)(ptr - str);
     return ch;
 }
 
@@ -343,11 +344,11 @@ CSSIdent css_new_ident(const char *str)
         }
         table_ident_allocated = n;
     }
-    len = strlen(str);
+    len = (int)strlen(str);
     p = qe_malloc_hack(CSSIdentEntry, len);
     if (!p)
         return CSS_ID_NIL;
-    memcpy(p->str, str, len + 1);
+    memcpy(p->str, str, (size_t)len + 1);
     p->id = table_ident_nb;
     table_ident[table_ident_nb++] = p;
     p->hash_next = *pp;
@@ -368,7 +369,7 @@ static void css_init_idents(void)
         r = p;
         while (*r)
             r++;
-        memcpy(buf, p, r - p);
+        memcpy(buf, p, (size_t)(r - p));
         buf[r - p] = '\0';
         css_new_ident(buf);
     }
@@ -733,7 +734,8 @@ static int css_eval(CSSContext *s,
 {
     const CSSPropertyDef *def;
     CSSPropertyStorage *ptr, *parent_ptr;
-    int type, val, i;
+    unsigned int type;
+    int val, i;
     CSSProperty *p;
     int pelement_found;
 
@@ -956,13 +958,13 @@ static int num_to_alpha(char *dest, int num, int upper)
 
     num--;
     while (num >= 26) {
-        *--p = letter + (num % 26);
+        *--p = (char)(letter + (num % 26));
         num /= 26;
         num -= 1;
     }
-    *--p = letter + num;
+    *--p = (char)(letter + num);
 
-    memcpy(dest, p, buf + countof(buf) - p);
+    memcpy(dest, p, (size_t)(buf + countof(buf) - p));
     return 0;
 }
 
@@ -1014,7 +1016,7 @@ static int num_to_roman(char *dest, int n, int upper)
         n /= 10;
         p += 2;
     }
-    memcpy(dest, q, buf + countof(buf) - q);
+    memcpy(dest, q, (size_t)(buf + countof(buf) - q));
     return 0;
 }
 
@@ -1440,7 +1442,7 @@ static int bidir_compute_attributes(CSSContext *ctx, BidirTypeLink *list_tab, in
     p->pos = s->pos;
     p++;
 
-    return p - list_tab;
+    return (int)(p - list_tab);
 }
 
 /* split the boxes so that the embedding is constant inside a
@@ -1477,7 +1479,7 @@ static void css_bidir_split_box(BidirSplitState *s,  CSSBox *box)
                 if (offset > box->u.buffer.start &&
                     l[0].level != l[-1].level) {
                     /* different level : split box */
-                    box->embedding_level = l[-1].level;
+                    box->embedding_level = (unsigned char)l[-1].level;
                     css_box_split(box, offset);
                     /* update next_inline field */
                     box->next->next_inline = box->next_inline;
@@ -1489,7 +1491,7 @@ static void css_bidir_split_box(BidirSplitState *s,  CSSBox *box)
             pos++;
         }
     }
-    box->embedding_level = l[0].level;
+    box->embedding_level = (unsigned char)l[0].level;
  the_end:
     s->l = l;
     s->pos = pos;
@@ -2021,7 +2023,7 @@ static void css_flush_line(InlineLayout *s,
             break;
         }
         /* put real ascent in box */
-        box->ascent = ib->ascent;
+        box->ascent = (unsigned short)ib->ascent;
         /* correct borders */
         if (props->display != CSS_DISPLAY_INLINE) {
             box->y += props->margin.y1 + props->border.y1 + props->padding.y1;
@@ -2132,7 +2134,7 @@ static int css_flush_fragment(InlineLayout *s, CSSBox *box, CSSState *props,
         if (h > box->height)
             box->height = h;
         if (metrics.font_ascent > s->line_boxes[s->line_pos - 1].ascent)
-            s->line_boxes[s->line_pos - 1].ascent = metrics.font_ascent;
+            s->line_boxes[s->line_pos - 1].ascent = (short)metrics.font_ascent;
         ret = 0;
     } else {
         /* end of line reached */
@@ -2154,7 +2156,7 @@ static int css_flush_fragment(InlineLayout *s, CSSBox *box, CSSState *props,
             if (h > box->height)
                 box->height = h;
             if (metrics.font_ascent > s->line_boxes[s->line_pos - 1].ascent)
-                s->line_boxes[s->line_pos - 1].ascent = metrics.font_ascent;
+                s->line_boxes[s->line_pos - 1].ascent = (short)metrics.font_ascent;
             s->index_bow = s->line_pos - 1;
             s->offset_bow = s->word_offsets[s->word_index];
         } else {
@@ -2311,9 +2313,9 @@ static int css_layout_inline_box(InlineLayout *s,
 
                 b->box = box;
                 b->baseline_delta = 0;
-                b->ascent = box->height +
+                b->ascent = (short)(box->height +
                     props->margin.y1 + props->border.y1 + props->padding.y1 +
-                    props->padding.y2 + props->border.y2 + props->margin.y2;
+                    props->padding.y2 + props->border.y2 + props->margin.y2);
             }
             s->line_pos++;
         }
@@ -2352,7 +2354,7 @@ static int css_layout_inline_box(InlineLayout *s,
 
         if (!s->compute_min_max) {
             box->width = 0;
-            box->last_space = s->last_space;
+            box->last_space = (unsigned char)s->last_space;
             /* compute vertical dimensions from the font parameters */
             box->height = font->ascent + font->descent;
 
@@ -2361,8 +2363,8 @@ static int css_layout_inline_box(InlineLayout *s,
                 InlineBox *b = &s->line_boxes[s->line_pos];
 
                 b->box = box;
-                b->baseline_delta = baseline;
-                b->ascent = font->ascent;
+                b->baseline_delta = (short)baseline;
+                b->ascent = (short)font->ascent;
             }
             s->line_pos++;
         }
@@ -3049,7 +3051,7 @@ static int render_table_row(TableLayout *s,
                 int delta = baseline - c->baseline;
                 cell = c->cell;
                 h += delta;
-                cell->padding_top = delta;
+                cell->padding_top = (unsigned short)delta;
                 cell->y += delta;
             }
             if (cell->props->height != CSS_AUTO)
@@ -3074,19 +3076,19 @@ static int render_table_row(TableLayout *s,
             switch (c->vertical_align) {
             case CSS_VERTICAL_ALIGN_BOTTOM:
                 delta = cell_height - c->height;
-                cell->padding_top = delta;
+                cell->padding_top = (unsigned short)delta;
                 cell->y += delta;
                 break;
             case CSS_VERTICAL_ALIGN_MIDDLE:
                 delta = (cell_height - c->height) / 2;
-                cell->padding_top = delta;
+                cell->padding_top = (unsigned short)delta;
                 cell->y += delta;
                 break;
             default:
                 break;
             }
             /* compute bottom padding so that we fill the row height */
-            cell->padding_bottom = cell_height - (h + cell->padding_top);
+            cell->padding_bottom = (unsigned short)(cell_height - (h + cell->padding_top));
         } else {
             c->prev_row_height = s->border_v + cell_height;
         }
@@ -3831,7 +3833,7 @@ int box_get_text(qe__unused__ CSSContext *s,
             *q++ = c;
         }
     }
-    return q - line_buf;
+    return (int)(q - line_buf);
 }
 
 #define BFRAC 16
@@ -3860,9 +3862,9 @@ static void draw_borders(QEditScreen *scr,
             g = (color1 >> 8) & 0xff;
             b = (color1) & 0xff;
 
-            r = min_int(r + 128, 255);
-            g = min_int(g + 128, 255);
-            b = min_int(b + 128, 255);
+            r = (unsigned int)min_int((int)r + 128, 255);
+            g = (unsigned int)min_int((int)g + 128, 255);
+            b = (unsigned int)min_int((int)b + 128, 255);
 
             color2 = (a << 24) | (r << 16) | (g << 8) | b;
             if ((style == CSS_BORDER_STYLE_INSET && dir >= 2) ||
@@ -3996,12 +3998,12 @@ static void box_display_text(CSSContext *s, CSSBox *box, int x0, int y0)
             offsets[len1] = box->u.buffer.end;
             x = x0;
             for (i = 0; i < len; i++) {
-                p = char_to_glyph_pos[i];
+                p = (int)char_to_glyph_pos[i];
                 offset0 = offsets[p];
                 w = glyph_width(scr, font, glyphs[i]);
                 if (offset0 >= s->selection_start &&
                     offset0 < s->selection_end) {
-                    color = s->selection_bgcolor;
+                    color = (CSSColor)s->selection_bgcolor;
                     fill_rectangle(scr, x, y0,
                                    w, font->ascent + font->descent, color);
                 }
@@ -4010,11 +4012,11 @@ static void box_display_text(CSSContext *s, CSSBox *box, int x0, int y0)
 
             x = x0;
             for (i = 0; i < len; i++) {
-                p = char_to_glyph_pos[i];
+                p = (int)char_to_glyph_pos[i];
                 offset0 = offsets[p];
                 if (offset0 >= s->selection_start &&
                     offset0 < s->selection_end)
-                    color = s->selection_fgcolor;
+                    color = (CSSColor)s->selection_fgcolor;
                 else
                     color = props->color;
                 draw_text(scr, font,
@@ -4108,12 +4110,12 @@ static void css_display_block(CSSContext *s,
     /* background + padding */
     /* XXX: hack to exclude HTML tag from these computations */
     if (!s->bg_drawn && box->tag != CSS_ID_html) {
-        int color;
+        CSSColor color;
         /* if no background drawn, we MUST draw one now with either
            the specified color or the default color */
         color = props->bgcolor;
         if (color == COLOR_TRANSPARENT)
-            color = s->default_bgcolor;
+            color = (CSSColor)s->default_bgcolor;
         fill_rectangle(scr, s->bg_rect.x1, s->bg_rect.y1,
                        s->bg_rect.x2 - s->bg_rect.x1,
                        s->bg_rect.y2 - s->bg_rect.y1, color);
@@ -4191,7 +4193,7 @@ void css_display(CSSContext *s, CSSBox *box,
         fill_rectangle(s->screen, s->bg_rect.x1, s->bg_rect.y1,
                        s->bg_rect.x2 - s->bg_rect.x1,
                        s->bg_rect.y2 - s->bg_rect.y1,
-                       s->default_bgcolor);
+                       (QEColor)s->default_bgcolor);
     }
 }
 
@@ -4257,7 +4259,7 @@ static int css_get_cursor_func(void *opaque,
  found1:
     len = unicode_to_glyphs(glyphs, char_to_glyph_pos, MAX_LINE_SIZE,
                             line_buf, len, box->embedding_level & 1);
-    posc = char_to_glyph_pos[posc];
+    posc = (int)char_to_glyph_pos[posc];
 
     font = css_select_font(scr, props);
 
@@ -4526,7 +4528,7 @@ void css_set_text_buffer(CSSBox *box, struct EditBuffer *b,
 {
     box->content_type = CSS_CONTENT_TYPE_BUFFER;
     box->content_data = b;
-    box->content_eol = eol;
+    box->content_eol = (eol != 0);
     box->u.buffer.start = offset1;
     box->u.buffer.end = offset2;
 }
@@ -4538,7 +4540,7 @@ void css_set_text_string(CSSBox *box, const char *string)
     box->content_data = qe_strdup(string);
     //box->content_eol = eol; // ???
     box->u.buffer.start = 0;
-    box->u.buffer.end = strlen(string);
+    box->u.buffer.end = (int)strlen(string);
 }
 
 void css_set_child_box(CSSBox *parent_box, CSSBox *box)

--- a/libqhtml/cssparse.c
+++ b/libqhtml/cssparse.c
@@ -77,20 +77,20 @@ static int css_get_length(int *length_ptr, int *unit_ptr, const char *p)
     p1 = p;
     if (*p == '+' || *p == '-')
         p++;
-    while (qe_isdigit(*p))
+    while (qe_isdigit((char32_t)(unsigned char)*p))
         p++;
     if (*p == '.') {
         p++;
-        while (qe_isdigit(*p))
+        while (qe_isdigit((char32_t)(unsigned char)*p))
             p++;
     }
-    len = p - p1;
+    len = (int)(p - p1);
     if (len == 0)
         return -1;
     /* CG: use pstrncpy */
     if (len > (int)sizeof(buf) - 1)
         len = (int)sizeof(buf) - 1;
-    memcpy(buf, p1, len);
+    memcpy(buf, p1, (size_t)len);
     buf[len] = '\0';
     f = strtod(buf, NULL);
     /* CG: should use define or global for consistency with
@@ -192,7 +192,7 @@ static char *css_parse_string(const char **pp)
             /* XXX: hex digits */
         }
         if ((q - buf) < (int)sizeof(buf) - 1)
-            *q++ = c;
+            *q++ = (char)c;
     }
     *q = '\0';
     //    printf("string='%s'\n", buf);
@@ -208,12 +208,12 @@ void css_add_prop_values(CSSProperty ***last_prop,
     CSSProperty *prop;
 
     prop = qe_malloc_hack(CSSProperty,
-                          (nb_values - 1) * sizeof(CSSPropertyValue));
+                          (size_t)(nb_values - 1) * sizeof(CSSPropertyValue));
     if (!prop)
         return;
-    prop->property = property_index;
+    prop->property = (unsigned short)property_index;
     prop->next = NULL;
-    prop->nb_values = nb_values;
+    prop->nb_values = (unsigned short)nb_values;
     blockcpy(&prop->value, val_ptr, nb_values);
 
     **last_prop = prop;
@@ -286,8 +286,8 @@ CSSProperty *css_parse_properties(CSSParseState *b, const char *props_str)
                 break;
             def++;
         }
-        property_index = def - css_properties;
-        type = def->type;
+        property_index = (int)(def - css_properties);
+        type = (int)def->type;
 
         nb_args = 0;
         for (;;) {
@@ -358,7 +358,7 @@ CSSProperty *css_parse_properties(CSSParseState *b, const char *props_str)
             get_str(&p, buf, sizeof(buf), ";");
 
             unit = CSS_UNIT_NONE;
-            if (type & CSS_TYPE_AUTO) {
+            if ((unsigned int)type & CSS_TYPE_AUTO) {
                 if (strequal(buf, "auto")) {
                     val = CSS_AUTO;
                     goto got_val;
@@ -372,7 +372,7 @@ CSSProperty *css_parse_properties(CSSParseState *b, const char *props_str)
             }
             if (type & CSS_TYPE_INTEGER) {
                 const char *p1;
-                val = strtol_c(buf, &p1, 0);
+                val = (int)strtol_c(buf, &p1, 0);
                 if (*p1 == '\0') {
                     unit = CSS_VALUE_INTEGER;
                     goto got_val;
@@ -412,7 +412,7 @@ CSSProperty *css_parse_properties(CSSParseState *b, const char *props_str)
                 QEColor color;
                 /* XXX: color parsing is not always discriminant */
                 if (!css_get_color(&color, buf)) {
-                    val = color;
+                    val = (int)color;
                     unit = CSS_VALUE_COLOR;
                     goto got_val;
                 }
@@ -732,7 +732,7 @@ static void read_string(CSSParseState *b, int *ch_ptr, char *ident, int ident_si
         if (ch == quote)
             break;
         if ((q - ident) < ident_size - 1)
-            *q++ = ch;
+            *q++ = (char)ch;
     }
     *q = '\0';
     ch = bgetc(b);
@@ -747,10 +747,10 @@ static void read_ident(CSSParseState *b, int *ch_ptr, char *ident, int ident_siz
     c = *ch_ptr;
     q = ident;
     for (;;) {
-        if (!(qe_isalnum_(c) || c == '*' || c == '-'))
+        if (!(qe_isalnum_((char32_t)c) || c == '*' || c == '-'))
             break;
         if ((q - ident) < ident_size - 1)
-            *q++ = c;
+            *q++ = (char)c;
         c = bgetc(b);
     }
     *q = '\0';
@@ -762,7 +762,7 @@ static void bskip_spaces(CSSParseState *b, int *ch_ptr)
     int c;
 
     c = *ch_ptr;
-    while (qe_isspace(c))
+    while (qe_isspace((char32_t)c))
         c = bgetc(b);
     *ch_ptr = c;
 }
@@ -771,12 +771,12 @@ void add_attribute(CSSStyleSheetAttributeEntry ***last_attr,
                    CSSIdent attr, int op, const char *value)
 {
     CSSStyleSheetAttributeEntry *ae;
-    int len = strlen(value);
+    int len = (int)strlen(value);
 
     ae = qe_malloc_hack(CSSStyleSheetAttributeEntry, len);
     ae->attr = attr;
-    ae->op = op;
-    memcpy(ae->value, value, len + 1);
+    ae->op = (unsigned char)op;
+    memcpy(ae->value, value, (size_t)(len + 1));
     ae->next = NULL;
     **last_attr = ae;
     *last_attr = &ae->next;
@@ -972,7 +972,7 @@ static void parse_simple_selector(CSSSimpleSelector *ss, // output only
         ss->tag_id = css_new_ident(tag_id);
     }
     ss->attrs = first_attr;
-    ss->pclasses = pclass;
+    ss->pclasses = (unsigned short)pclass;
 
     *ch_ptr = ch;
 }
@@ -1065,7 +1065,7 @@ void css_parse_style_sheet(CSSStyleSheet *s, CSSParseState *b)
                 bskip_spaces(b, &ch);
                 parse_simple_selector(ss, b, &ch);
                 bskip_spaces(b, &ch);
-                ss->tree_op = last_tree_op;
+                ss->tree_op = (unsigned char)last_tree_op;
                 ss->next = last_ss;
                 if (ch == '+') {
                     tree_op = CSS_TREE_OP_PRECEEDED;
@@ -1077,7 +1077,7 @@ void css_parse_style_sheet(CSSStyleSheet *s, CSSParseState *b)
                     ch = bgetc(b);
                     goto add_tree;
                 } else
-                if (qe_isalpha(ch)) {
+                if (qe_isalpha((char32_t)ch)) {
                     tree_op = CSS_TREE_OP_DESCENDANT;
                 add_tree:
                     ss1 = qe_malloc_dup_array(ss, 1);
@@ -1106,7 +1106,7 @@ void css_parse_style_sheet(CSSStyleSheet *s, CSSParseState *b)
         q = value;
         while (ch != '}' && ch != EOF) {
             if ((q - value) < (int)sizeof(value) - 1)
-                *q++ = ch;
+                *q++ = (char)ch;
             ch = bgetc(b);
         }
         *q = '\0';

--- a/libqhtml/xmlparse.c
+++ b/libqhtml/xmlparse.c
@@ -75,9 +75,9 @@ int find_entity(const char *str)
 
     if (str[0] == '#') {
         if (str[1] == 'x')
-            code = strtol(str + 2, NULL, 16);
+            code = (int)strtol(str + 2, NULL, 16);
         else
-            code = strtol(str + 1, NULL, 10);
+            code = (int)strtol(str + 1, NULL, 10);
         if (code <= 0)
             return -1;
         return code;
@@ -129,7 +129,7 @@ static int parse_entity(const char **pp)
             p++;
             if (ch1 == ';')
                 break;
-            *q++ = ch1;
+            *q++ = (char)ch1;
             if (q >= name + sizeof(name) - 1)
                 break;
         }
@@ -192,7 +192,7 @@ static void strbuf_addch1(StringBuffer *b, char32_t ch)
     ptr = b->buf;
     if (b->buf == b->buf1)
         ptr = NULL;
-    if (qe_realloc_bytes(&ptr, size1)) {
+    if (qe_realloc_bytes(&ptr, (size_t)size1)) {
         if (b->buf == b->buf1)
             memcpy(ptr, b->buf1, STRING_BUF_SIZE);
         b->buf = ptr;
@@ -325,14 +325,14 @@ XMLState *xml_begin(CSSStyleSheet *style_sheet, int flags,
 static CSSAttribute *box_new_attr(CSSIdent attr_id, const char *value)
 {
     CSSAttribute *attr;
-    int len = strlen(value);
+    int len = (int)strlen(value);
 
     attr = qe_malloc_hack(CSSAttribute, len);
     if (!attr)
         return NULL;
     attr->attr = attr_id;
     attr->next = NULL;
-    memcpy(attr->value, value, len + 1);
+    memcpy(attr->value, value, (size_t)(len + 1));
     return attr;
 }
 
@@ -370,7 +370,7 @@ static int css_attr_int(CSSBox *box, CSSIdent attr_id, int def_val)
     str = css_attr_str(box, attr_id);
     if (!str)
         return def_val;
-    val = strtol_c(str, &p, 10);
+    val = (int)strtol_c(str, &p, 10);
     /* exclude non numeric inputs (for example percentages) */
     if (*p != '\0')
         return def_val;
@@ -513,7 +513,7 @@ static void html_eval_tag(XMLState *s, CSSBox *box)
     case CSS_ID_body:
         value = css_attr_str(box, CSS_ID_text);
         if (value && !css_get_color(&color, value)) {
-            css_add_prop_int(&last_prop, CSS_color, color);
+            css_add_prop_int(&last_prop, CSS_color, (int)color);
         }
         /* we handle link by adding a new stylesheet entry */
         value = css_attr_str(box, CSS_ID_link);
@@ -533,7 +533,7 @@ static void html_eval_tag(XMLState *s, CSSBox *box)
 
             /* add color property */
             last_prop1 = &e->props;
-            css_add_prop_int(&last_prop1, CSS_color, color);
+            css_add_prop_int(&last_prop1, CSS_color, (int)color);
         }
         break;
     case CSS_ID_font:
@@ -541,7 +541,7 @@ static void html_eval_tag(XMLState *s, CSSBox *box)
         /* size */
         value = css_attr_str(box, CSS_ID_size);
         if (value) {
-            val = strtol(value, NULL, 10);
+            val = (int)strtol(value, NULL, 10);
             if (value[0] == '+' || value[0] == '-') {
                 /* relative size */
                 val += s->base_font;
@@ -560,7 +560,7 @@ static void html_eval_tag(XMLState *s, CSSBox *box)
         /* color */
         value = css_attr_str(box, CSS_ID_color);
         if (value && !css_get_color(&color, value)) {
-            css_add_prop_int(&last_prop, CSS_color, color);
+            css_add_prop_int(&last_prop, CSS_color, (int)color);
         }
         break;
     case CSS_ID_br:
@@ -734,7 +734,7 @@ static void html_eval_tag(XMLState *s, CSSBox *box)
     /* generic attributes */
     value = css_attr_str(box, CSS_ID_bgcolor);
     if (value && !css_get_color(&color, value)) {
-        css_add_prop_int(&last_prop, CSS_background_color, color);
+        css_add_prop_int(&last_prop, CSS_background_color, (int)color);
     }
     value = css_attr_strlower(box, CSS_ID_align);
     if (value) {
@@ -902,7 +902,7 @@ static int parse_tag(XMLState *s, const char *buf)
                 while (*p != '\0' && !strchr(" \t\n\r<>", *p)) {
                     ch = parse_entity(&p);
                     if ((q - value) < (int)sizeof(value) - 1)
-                        *q++ = ch;
+                        *q++ = (char)ch;
                 }
                 *q = '\0';
             } else {
@@ -911,7 +911,7 @@ static int parse_tag(XMLState *s, const char *buf)
                 while (*p != och && *p != '\0' && *p != '<') {
                     ch = parse_entity(&p);
                     if ((q - value) < (int)sizeof(value) - 1)
-                        *q++ = ch;
+                        *q++ = (char)ch;
                 }
                 *q = '\0';
                 if (*p != och) {
@@ -968,11 +968,11 @@ static int parse_tag(XMLState *s, const char *buf)
         css_tag == CSS_ID_programlisting) {
     pretag:
         pstrcpy(s->pretag, sizeof(s->pretag), tag);
-        s->pretaglen = strlen(s->pretag);
+        s->pretaglen = (int)strlen(s->pretag);
         return XML_STATE_PRETAG;
     }
 
-    len = strlen(buf);
+    len = (char)strlen(buf);
     /* end of tag. If html, check also some common mistakes. FORM is
        considered as self closing to avoid any content problems */
     if ((len > 0 && buf[len - 1] == '/') ||
@@ -1072,9 +1072,9 @@ static void flush_text_buffer(XMLState *s, struct EditBuffer *b,
 
 static int xml_tagcmp(const char *s1, const char *s2) {
     while (*s2) {
-        unsigned char uc1 = *s1++;
-        unsigned char uc2 = *s2++;
-        int d = uc2 - qe_tolower(uc1);
+        unsigned char uc1 = (unsigned char)*s1++;
+        unsigned char uc2 = (unsigned char)*s2++;
+        int d = uc2 - (int)qe_tolower(uc1);
         if (d)
             return d;
     }
@@ -1163,7 +1163,7 @@ static int xml_parse_internal(XMLState *s, const char *buf_start, int buf_len,
                     /* evaluate entities */
                     if (ch == '&') {
                         buf--;
-                        ch = parse_entity(&buf);
+                        ch = (char32_t)parse_entity(&buf);
                     }
                     strbuf_addch(&s->str, ch);
                 }
@@ -1235,7 +1235,7 @@ static int xml_parse_internal(XMLState *s, const char *buf_start, int buf_len,
         }
     }
     /* CG: incorrect if parsing from buffer */
-    return buf - buf_start;
+    return (int)(buf - buf_start);
 }
 
 int xml_parse(XMLState *s, char *buf, int buf_len)
@@ -1248,7 +1248,7 @@ int xml_parse(XMLState *s, char *buf, int buf_len)
         len = LOOKAHEAD_SIZE - 1;
         if (len > buf_len)
             len = buf_len;
-        memcpy(s->lookahead_buf + s->lookahead_size, buf, len);
+        memcpy(s->lookahead_buf + s->lookahead_size, buf, (size_t)len);
         len += s->lookahead_size; /* total chars in lookahead buffer */
 
         /* parse only if enough chars for lookahead */
@@ -1260,7 +1260,7 @@ int xml_parse(XMLState *s, char *buf, int buf_len)
             len1 = len - s->lookahead_size;
             if (len1 <= 0) {
                 s->lookahead_size -= len;
-                memmove(s->lookahead_buf, s->lookahead_buf + len, s->lookahead_size);
+                memmove(s->lookahead_buf, s->lookahead_buf + len, (size_t)s->lookahead_size);
             } else {
                 buf_len -= len1;
                 buf += len1;
@@ -1287,7 +1287,7 @@ int xml_parse(XMLState *s, char *buf, int buf_len)
     }
 
     /* put all the remaining chars in the lookahead buffer */
-    memcpy(s->lookahead_buf, buf, buf_len);
+    memcpy(s->lookahead_buf, buf, (size_t)buf_len);
     s->lookahead_size = buf_len;
     return 0;
 }

--- a/libregexp.h
+++ b/libregexp.h
@@ -68,7 +68,7 @@ static inline int lre_js_is_ident_first(int c)
         return (lre_id_start_table_ascii[c >> 5] >> (c & 31)) & 1;
     } else {
 #ifdef CONFIG_ALL_UNICODE
-        return lre_is_id_start(c);
+        return lre_is_id_start((uint32_t)c);
 #else
         return !lre_is_space(c);
 #endif
@@ -82,7 +82,7 @@ static inline int lre_js_is_ident_next(int c)
     } else {
         /* ZWNJ and ZWJ are accepted in identifiers */
 #ifdef CONFIG_ALL_UNICODE
-        return lre_is_id_continue(c) || c == 0x200C || c == 0x200D;
+        return lre_is_id_continue((uint32_t)c) || c == 0x200C || c == 0x200D;
 #else
         return !lre_is_space(c) || c == 0x200C || c == 0x200D;
 #endif

--- a/modes/archive.c
+++ b/modes/archive.c
@@ -65,7 +65,7 @@ static ArchiveType *find_archive_type(const char *filename,
     reduce_filename(rname, sizeof(rname), get_basename(filename));
     for (atp = archive_types; atp; atp = atp->next) {
         if (atp->magic_size && atp->magic_size <= buf_size
-        &&  !memcmp(atp->magic, buf, atp->magic_size))
+        &&  !memcmp(atp->magic, buf, (size_t)atp->magic_size))
             return atp;
         if (match_extension(rname, atp->extensions))
             return atp;
@@ -113,7 +113,7 @@ static int qe_shell_subst(char *buf, int size, const char *cmd,
                 continue;
             }
         }
-        buf_put_byte(out, *cmd++);
+        buf_put_byte(out, (unsigned char)*cmd++);
     }
     return out->len;
 }
@@ -126,7 +126,7 @@ static int file_read_block(EditBuffer *b, FILE *f1, u8 *buf, int buf_size)
     if (!f)
         f = fopen(b->filename, "rb");
     if (f)
-        nread = fread(buf, 1, buf_size, f);
+        nread = (int)fread(buf, 1, (size_t)buf_size, f);
     if (f && !f1)
         fclose(f);
     return nread;
@@ -256,7 +256,7 @@ static CompressType *find_compress_type(const char *filename,
     reduce_filename(rname, sizeof(rname), get_basename(filename));
     for (ctp = compress_types; ctp; ctp = ctp->next) {
         if (ctp->magic && ctp->magic_size && ctp->magic_size <= buf_size
-        &&  !memcmp(ctp->magic, buf, ctp->magic_size))
+        &&  !memcmp(ctp->magic, buf, (size_t)ctp->magic_size))
             return ctp;
         if (match_extension(rname, ctp->extensions))
             return ctp;

--- a/modes/bufed.c
+++ b/modes/bufed.c
@@ -148,7 +148,7 @@ static void build_bufed_list(EditState *s, BufedState *bs)
     bs->sort_mode = bufed_sort_order;
 
     if (bufed_sort_order) {
-        qe_qsort_r(bs->items.items, bs->items.nb_items,
+        qe_qsort_r(bs->items.items, (size_t)bs->items.nb_items,
                    sizeof(StringItem *), bs, bufed_sort_func);
     }
 
@@ -167,7 +167,8 @@ static void build_bufed_list(EditState *s, BufedState *bs)
     for (i = 0; i < bs->items.nb_items; i++) {
         char flags[4];
         char *flagp = flags;
-        int len, style0;
+        int len;
+        QETermStyle style0;
 
         item = bs->items.items[i];
         b1 = qe_check_buffer(qs, (EditBuffer**)(void *)&item->opaque);
@@ -193,7 +194,7 @@ static void build_bufed_list(EditState *s, BufedState *bs)
         b->cur_style = style0;
         eb_printf(b, " %-2s", flags);
         b->cur_style = BUFED_STYLE_BUFNAME;
-        len = strlen(item->str);
+        len = (int)strlen(item->str);
         /* simplistic column fitting, does not work for wide characters */
 #define COLWIDTH  20
         if (len > COLWIDTH) {

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -194,7 +194,7 @@ static const char *dired_get_cur_filename(DiredState *ds, EditState *s,
 {
     DiredItem *dip = dired_get_cur_item(ds, s);
     if (dip) {
-        pstrcpy(buf, buf_size, dip->fullname);
+        pstrcpy(buf, (int)buf_size, dip->fullname);
         return buf;
     }
     return NULL;
@@ -358,7 +358,7 @@ static int dired_sort_func(void *opaque, const void *p1, const void *p2)
 static int format_number(char *buf, int size, int human, off_t number)
 {
     if (human == 0) {
-        return snprintf(buf, size, "%lld", (long long)number);
+        return snprintf(buf, (size_t)size, "%lld", (long long)number);
     }
     if (human > 1) {
         const char *suffix = "BkMGTPEZY";
@@ -366,9 +366,9 @@ static int format_number(char *buf, int size, int human, off_t number)
         /* metric version, powers of 1000 */
         while (suffix[1] && number >= 1000) {
             if (number < 10000) {
-                buf[0] = '0' + (number / 1000);
+                buf[0] = (char)('0' + (number / 1000));
                 buf[1] = '.';
-                buf[2] = '0' + ((number / 100) % 10);
+                buf[2] = (char)('0' + ((number / 100) % 10));
                 buf[3] = suffix[1];
                 buf[4] = '\0';
                 return 4;
@@ -376,16 +376,16 @@ static int format_number(char *buf, int size, int human, off_t number)
             number /= 1000;
             suffix++;
         }
-        return snprintf(buf, size, "%d%c", (int)number, *suffix);
+        return snprintf(buf, (size_t)size, "%d%c", (int)number, *suffix);
     } else {
         const char *suffix = "BKMGTPEZY";
 
         /* geek version, powers of 1024 */
         while (suffix[1] && number >= 1000) {
             if (number < 10200) {
-                buf[0] = '0' + (number / 1020);
+                buf[0] = (char)('0' + (number / 1020));
                 buf[1] = '.';
-                buf[2] = '0' + ((number / 102) % 10);
+                buf[2] = (char)('0' + ((number / 102) % 10));
                 buf[3] = suffix[1];
                 buf[4] = '\0';
                 return 4;
@@ -393,7 +393,7 @@ static int format_number(char *buf, int size, int human, off_t number)
             number >>= 10;
             suffix++;
         }
-        return snprintf(buf, size, "%d%c", (int)number, *suffix);
+        return snprintf(buf, (size_t)size, "%d%c", (int)number, *suffix);
     }
 }
 
@@ -403,9 +403,9 @@ static int format_gid(char *buf, int size, int nflag, gid_t gid)
     struct group *grp;
 
     if (!nflag && (grp = getgrgid(gid)) != NULL && grp->gr_name)
-        return snprintf(buf, size, "%s", grp->gr_name);
+        return snprintf(buf, (size_t)size, "%s", grp->gr_name);
     else
-        return snprintf(buf, size, "%d", (int)gid);
+        return snprintf(buf, (size_t)size, "%d", (int)gid);
 }
 
 static int format_uid(char *buf, int size, int nflag, uid_t uid)
@@ -414,18 +414,18 @@ static int format_uid(char *buf, int size, int nflag, uid_t uid)
     struct passwd *pwp;
 
     if (!nflag && (pwp = getpwuid(uid)) != NULL && pwp->pw_name)
-        return snprintf(buf, size, "%s", pwp->pw_name);
+        return snprintf(buf, (size_t)size, "%s", pwp->pw_name);
     else
-        return snprintf(buf, size, "%d", (int)uid);
+        return snprintf(buf, (size_t)size, "%d", (int)uid);
 }
 
 static int format_size(char *buf, int size, int human,
                        mode_t st_mode, dev_t st_rdev, off_t st_size)
 {
     if (S_ISCHR(st_mode) || S_ISBLK(st_mode)) {
-        int major = st_rdev >> ((sizeof(dev_t) == 2) ? 8 : 24);
-        int minor = st_rdev & ((sizeof(dev_t) == 2) ? 0xff : 0xffffff);
-        return snprintf(buf, size, "%3d, %3d", major, minor);
+        int major = (int)(st_rdev >> ((sizeof(dev_t) == 2) ? 8 : 24));
+        int minor = (int)(st_rdev & ((sizeof(dev_t) == 2) ? 0xff : 0xffffff));
+        return snprintf(buf, (size_t)size, "%3d, %3d", major, minor);
     } else {
         return format_number(buf, size, human, st_size);
     }
@@ -510,7 +510,7 @@ static int format_date(char *dest, int size,
     }
 
     if (!fmonth) {
-        memset(dest, ' ', out->len);
+        memset(dest, ' ', (size_t)out->len);
     }
     return out->pos;
 }
@@ -546,7 +546,7 @@ static int get_trailchar(mode_t mode)
 static char *getentryslink(char *path, int size, const char *filename)
 {
     /* Warning: readlink does not append a null byte! */
-    int len = readlink(filename, path, size - 1);
+    int len = (int)readlink(filename, path, (size_t)(size - 1));
     if (len < 0)
         len = 0;
     path[len] = '\0';
@@ -648,7 +648,7 @@ static void dired_filter_files(DiredState *ds)
         }
         /* XXX: should apply other filters? */
         // XXX: should hide full subtree if grouped?
-        dip->hidden = hidden;
+        dip->hidden = (char)hidden;
         if (hidden) {
             if (S_ISDIR(dip->mode)) {
                 ds->ndirs_hidden++;
@@ -682,7 +682,7 @@ static void dired_compute_columns(DiredState *ds)
     for (i = 0; i < ds->nb_items; i++) {
         DiredItem *dip = ds->items[i];
 
-        len = strlen(dip->name);
+        len = (int)strlen(dip->name);
         if (ds->namelen < len)
             ds->namelen = len;
 
@@ -725,7 +725,7 @@ static int dired_format_details(DiredState *ds, DiredItem *dip,
     char buf[32];
     buf_t bp[1];
 
-    buf_init(bp, dest, size);
+    buf_init(bp, dest, (int)size);
 
 #if 0
     if (details_mask & DIRED_SHOW_BLOCKS) {
@@ -804,7 +804,7 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
     if (flags & DIRED_UPDATE_SORT) {
         flags |= DIRED_UPDATE_REBUILD;
         ds->sort_mode = dired_sort_mode;
-        qe_qsort_r(ds->items, ds->nb_items, sizeof(DiredItem *),
+        qe_qsort_r(ds->items, (size_t)ds->nb_items, sizeof(DiredItem *),
                    ds, dired_sort_func);
     }
 
@@ -944,7 +944,7 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
         if (*fname != '/' || fname[1]) {
             int trailchar = get_trailchar(dip->mode);
             if (trailchar) {
-                eb_putc(b, trailchar);
+                eb_putc(b, (char32_t)trailchar);
             }
         }
         if (S_ISLNK(dip->mode)
@@ -1001,7 +1001,8 @@ static void dired_mark(EditState *s, int mark)
 
     dip = dired_get_cur_item(ds, s);
     if (dip) {
-        ch = dip->mark = mark;
+        dip->mark = (char)mark;
+        ch = (char32_t)(unsigned char)mark;
         do_bol(s);
         flags = s->b->flags & BF_READONLY;
         s->b->flags ^= flags;
@@ -1218,7 +1219,7 @@ static DiredItem *dired_add_item(DiredState *ds, const char *name,
     dip->hidden = 0;
     dip->mark = ' ';
     dip->tick = ' ';
-    dip->level = level;
+    dip->level = (u8)level;
     if (dip->flags & DI_ISDIR)
         dip->tick = '>';
     memcpy(dip->fullname, fullname, fullname_size);
@@ -1603,7 +1604,7 @@ static char *dired_get_default_path(EditBuffer *b, int offset,
         append_slash(buf, buf_size);
         return buf;
     } else {
-        return getcwd(buf, buf_size) ? buf : NULL;
+        return getcwd(buf, (size_t)buf_size) ? buf : NULL;
     }
 }
 
@@ -1991,19 +1992,19 @@ static void filelist_display_hook(EditState *s)
         target_line = 0;
         if (access(filename, R_OK)) {
             /* try parsing an error message: `:` or `(` a linenumber */
-            i = strcspn(buf, ":(");
+            i = (int)strcspn(buf, ":(");
             if (i < len) {
                 char c = buf[i];
                 buf[i] = '\0';
                 makepath(filename, sizeof(filename), dir, buf);
                 buf[i] = c;
-                target_line = strtol(buf + i + 1, NULL, 10);
+                target_line = (int)strtol(buf + i + 1, NULL, 10);
             }
             i = 0;
             while (access(filename, R_OK)) {
                 /* try skipping initial words */
-                i += strcspn(buf + i, " ");
-                i += strspn(buf + i, " ");
+                i += (int)strcspn(buf + i, " ");
+                i += (int)strspn(buf + i, " ");
                 if (i == len)
                     break;
                 makepath(filename, sizeof(filename), dir, buf + i);

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -1210,7 +1210,7 @@ static DiredItem *dired_add_item(DiredState *ds, const char *name,
         dip->flags |= DI_ISDIR;
     }
     dip->mode = st.st_mode;
-    dip->nlink = st.st_nlink;
+    dip->nlink = (nlink_t)st.st_nlink;
     dip->uid = st.st_uid;
     dip->gid = st.st_gid;
     dip->rdev = st.st_rdev;

--- a/modes/fractal.c
+++ b/modes/fractal.c
@@ -154,10 +154,10 @@ static void fractint_colorize_line(QEColorizeContext *cp,
         default:
             if (!(state & IN_FRACTINT_BLOCK)) {
                 klen = 0;
-                kbuf[klen++] = qe_tolower(c);
+                kbuf[klen++] = (char)qe_tolower(c);
                 while (i < n && str[i] != '{') {
                     if (str[i] != ' ' && klen < countof(kbuf) - 1)
-                        kbuf[klen++] = qe_tolower(str[i]);
+                        kbuf[klen++] = (char)qe_tolower(str[i]);
                     i++;
                 }
                 if (kbuf[klen - 1] == '=')
@@ -228,10 +228,10 @@ static void fractint_colorize_line(QEColorizeContext *cp,
                  * "[a-zA-Z_\x80-\xff][a-zA-Z_0-9\x80-\xff]*"
                  */
                 klen = 0;
-                kbuf[klen++] = qe_tolower(c);
+                kbuf[klen++] = (char)qe_tolower(c);
                 while (qe_isalnum_(str[i]) || str[i] == '.') {
                     if (klen < countof(kbuf) - 1)
-                        kbuf[klen++] = qe_tolower(str[i]);
+                        kbuf[klen++] = (char)qe_tolower(str[i]);
                     i++;
                 }
                 kbuf[klen] = '\0';
@@ -613,7 +613,7 @@ static int fractal_set_colors(FractalState *ms, const char *p, const char **pp) 
                 if (*p == '<') {
                     if (i == 0)
                         return 0;
-                    n = clamp_int(strtol_c(p + 1, &p, 10), 1, 255 - i);
+                    n = clamp_int((int)strtol_c(p + 1, &p, 10), 1, 255 - i);
                     if (*p != '>')
                         return 0;
                     p++;
@@ -652,10 +652,10 @@ static void fractal_set_parameters(EditState *s, FractalState *ms, const char *p
             break;
         if (strstart(p, "type=", &p)) {
             // XXX: should match type names
-            ms->type = clamp_int(strtol_c(p, &p, 0), 0, countof(fractal_type) - 1);
+            ms->type = clamp_int((int)strtol_c(p, &p, 0), 0, countof(fractal_type) - 1);
         } else
         if (strstart(p, "maxiter=", &p)) {
-            ms->maxiter = strtol_c(p, &p, 0);
+            ms->maxiter = (int)strtol_c(p, &p, 0);
         } else
         if (strstart(p, "colors=", &p)) {
             if (!fractal_set_colors(ms, p, &p)) {
@@ -664,19 +664,19 @@ static void fractal_set_parameters(EditState *s, FractalState *ms, const char *p
             }
         } else
         if (strstart(p, "cb=", &p)) {
-            ms->cb = strtol_c(p, &p, 0);
+            ms->cb = (int)strtol_c(p, &p, 0);
         } else
         if (strstart(p, "nc=", &p)) {
-            ms->nc = strtol_c(p, &p, 0);
+            ms->nc = (int)strtol_c(p, &p, 0);
         } else
         if (strstart(p, "shift=", &p)) {
-            ms->shift = strtol_c(p, &p, 0);
+            ms->shift = (int)strtol_c(p, &p, 0);
         } else
         if (strstart(p, "rot=", &p)) {
-            fractal_set_rotation(ms, strtol_c(p, &p, 0));
+            fractal_set_rotation(ms, (int)strtol_c(p, &p, 0));
         } else
         if (strstart(p, "zoom=", &p)) {
-            fractal_set_zoom(ms, strtol_c(p, &p, 0));
+            fractal_set_zoom(ms, (int)strtol_c(p, &p, 0));
         } else
         if (strstart(p, "bailout=", &p)) {
             ms->bailout = strtold_c(p, &p);
@@ -802,7 +802,7 @@ static void do_fractal_draw(EditState *s, FractalState *ms)
             xr = xc + x * ms->m0 + y * ms->m1;
             yr = yc + x * ms->m2 + y * ms->m3;
             i = (*func)(xr, yr, bailout, maxiter);
-            pb[nx] = (i >= maxiter) ? 0 : cb + i % nc;
+            pb[nx] = (unsigned char)((i >= maxiter) ? 0 : cb + i % nc);
         }
     }
     edit_invalidate(s, 1);
@@ -871,7 +871,7 @@ static void fractal_display(EditState *s) {
 
             bmp_draw(s->screen, ms->disp_bmp,
                      s->xleft + x, s->ytop + y, w, h, 0, 0, 0);
-            fill_window_slack(s, x, y, w, h, col);
+            fill_window_slack(s, x, y, w, h, (int)col);
         } else {
             fill_rectangle(s->screen, s->xleft, s->ytop, s->width, s->height, col);
         }
@@ -917,7 +917,7 @@ static void fractal_display(EditState *s) {
                             ms->ip, 0, 0, w, h * s->screen->dpy.yfactor,
                             0, QERGB(128, 128, 128));
             ms->ip->palette = NULL;
-            fill_window_slack(s, x0, y0, w, h, col);
+            fill_window_slack(s, x0, y0, w, h, (int)col);
         } else {
             fill_rectangle(s->screen, s->xleft, s->ytop, s->width, s->height, col);
         }

--- a/modes/hex.c
+++ b/modes/hex.c
@@ -112,7 +112,7 @@ static int hex_display_line(EditState *s, DisplayState *ds, int offset)
                 offset1 = offset2 = -1;
             }
         }
-        display_char(ds, offset1, offset2, bin_to_disp(b));
+        display_char(ds, offset1, offset2, (char32_t)bin_to_disp(b));
     }
     display_eol(ds, -1, -1);
 
@@ -263,16 +263,16 @@ void hex_write_char(EditState *s, int key)
             hsize = s->unihex_mode;
         else
             hsize = 2;
-        h = qe_digit_value(key);
+        h = (int)qe_digit_value((char32_t)key);
         if (h >= 16)
             return;
         if ((!s->overwrite || offset >= s->b->total_size) && s->hex_nibble == 0) {
-            ch = h << ((hsize - 1) * 4);
+            ch = (char32_t)(h << ((hsize - 1) * 4));
             if (s->unihex_mode || s->b->charset->char_size > 1) {
                 len = eb_encode_char32(s->b, buf, ch);
             } else {
                 len = 1;
-                buf[0] = ch;
+                buf[0] = (char)ch;
             }
             eb_insert(s->b, offset, buf, len);
         } else {
@@ -286,13 +286,13 @@ void hex_write_char(EditState *s, int key)
             }
 
             shift = (hsize - s->hex_nibble - 1) * 4;
-            ch = (cur_ch & ~(0xf << shift)) | (h << shift);
+            ch = (char32_t)((cur_ch & ~((unsigned int)0xf << shift)) | ((unsigned int)h << shift));
 
             if (s->unihex_mode) {
                 len = eb_encode_char32(s->b, buf, ch);
             } else {
                 len = 1;
-                buf[0] = ch;
+                buf[0] = (char)ch;
             }
 #if 1
             // XXX: offset and mark may be udated differently

--- a/modes/html.c
+++ b/modes/html.c
@@ -204,9 +204,9 @@ static void html_display(EditState *s)
         css_merge_style_sheet(hs->css_ctx->style_sheet, hs->default_style_sheet);
 
         /* default colors */
-        hs->css_ctx->selection_bgcolor = qe_styles[QE_STYLE_SELECTION].bg_color;
-        hs->css_ctx->selection_fgcolor = qe_styles[QE_STYLE_SELECTION].fg_color;
-        hs->css_ctx->default_bgcolor = qe_styles[QE_STYLE_CSS_DEFAULT].bg_color;
+        hs->css_ctx->selection_bgcolor = (int)qe_styles[QE_STYLE_SELECTION].bg_color;
+        hs->css_ctx->selection_fgcolor = (int)qe_styles[QE_STYLE_SELECTION].fg_color;
+        hs->css_ctx->default_bgcolor = (int)qe_styles[QE_STYLE_CSS_DEFAULT].bg_color;
 
         timer_start();
         hs->top_box = xml_parse_buffer(s->b, s->b->name, 0, s->b->total_size,

--- a/modes/markdown.c
+++ b/modes/markdown.c
@@ -265,12 +265,12 @@ static void mkd_colorize_line(QEColorizeContext *cp,
         /* extract info-string */
         for (len = 0; i < n && !qe_isblank(str[i]); i++) {
             if (len < countof(lang_name) - 1)
-                lang_name[len++] = str[i];
+                lang_name[len++] = (char)str[i];
         }
         lang_name[len] = '\0';
         if (len) {
             /* XXX: unrecognised info-string should select text-mode */
-            lang = mkd_add_lang(cp->s->qs, lang_name, str[j]);
+            lang = mkd_add_lang(cp->s->qs, lang_name, (char)str[j]);
         } else
         if (lang == 0) {
             // get default lang is from mode;
@@ -433,7 +433,7 @@ static void mkd_colorize_line(QEColorizeContext *cp,
                 break;
             /* match an email address */
             for (flags = 0, j = i + 1; j < n;) {
-                int d = str[j++];
+                char32_t d = str[j++];
                 if (d == '@')
                     flags++;
                 if (d == '>') {
@@ -445,7 +445,7 @@ static void mkd_colorize_line(QEColorizeContext *cp,
             }
             break;
         case '\\':  /* escape */
-            if (strchr("\\`*_{}[]()#+-.!", str[i + 1])) {
+            if (strchr("\\`*_{}[]()#+-.!", (int)str[i + 1])) {
                 chunk = 2;
                 break;
             }
@@ -617,8 +617,8 @@ static void do_mkd_goto(EditState *s, const char *dest)
      */
 
     /* Jump to numbered destination. */
-    for (offset = 0, level = 0; qe_isdigit(*p); ) {
-        nb = strtol_c(p, &p, 10);
+    for (offset = 0, level = 0; qe_isdigit((u8)*p); ) {
+        nb = (int)strtol_c(p, &p, 10);
         if (*p == '.')
             p++;
         level++;

--- a/modes/mkd_render.c
+++ b/modes/mkd_render.c
@@ -184,7 +184,7 @@ static int mkd_render_display_line(EditState *s, DisplayState *ds, int offset)
     case MKD_LINE_HEADING: {
         int content_off;
         int level = mkd_render_heading_level(buf, &content_off);
-        int style = heading_styles[(level - 1) % 6];
+        QETermStyle style = (QETermStyle)heading_styles[(level - 1) % 6];
 
         /* Heading decorator + space */
         ds->style = style;

--- a/modes/orgmode.c
+++ b/modes/orgmode.c
@@ -139,7 +139,7 @@ static void org_colorize_line(QEColorizeContext *cp,
 
             kw = org_todo_keyword(str + i);
             if (kw > -1) {
-                j = i + strlen(OrgTodoKeywords[kw].keyword) + 1;
+                j = i + (int)strlen(OrgTodoKeywords[kw].keyword) + 1;
                 SET_STYLE(sbuf, i, j, OrgTodoKeywords[kw].style);
                 i = j;
             }
@@ -443,8 +443,8 @@ static void do_org_goto(EditState *s, const char *dest)
      */
 
     /* Jump to numbered destination. */
-    for (offset = 0, level = 0; qe_isdigit(*p); ) {
-        nb = strtol_c(p, &p, 10);
+    for (offset = 0, level = 0; qe_isdigit((u8)*p); ) {
+        nb = (int)strtol_c(p, &p, 10);
         if (*p == '.')
             p++;
         level++;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -72,7 +72,7 @@ typedef struct ShellState {
     int cur_prompt; /* offset of end of prompt on current line */
     int save_x, save_y;
     int nb_params;
-#define CSI_PARAM_OMITTED  0x80000000
+#define CSI_PARAM_OMITTED  (int)0x80000000U
     int params[MAX_CSI_PARAMS + 1];
     int state;
     int esc1, esc2;
@@ -151,7 +151,7 @@ static int get_pty(int *master_fd, int *slave_fd)
         static const char ptychar2[] = "0123456789abcdef";
         char ptydev[] = "/dev/pty??";
         char ttydev[] = "/dev/tty??";
-        int len = strlen(ttydev);
+        int len = (int)strlen(ttydev);
         const char *c1, *c2;
 
         for (c1 = ptychar1; *c1; c1++) {
@@ -209,8 +209,8 @@ static int run_process(ShellState *s,
     fcntl(pty_fd, F_SETFD, FD_CLOEXEC);
 
     /* set screen size on the master */
-    ws.ws_col = cols;
-    ws.ws_row = rows;
+    ws.ws_col = (uint16_t)cols;
+    ws.ws_row = (uint16_t)rows;
     ws.ws_xpixel = ws.ws_col;
     ws.ws_ypixel = ws.ws_row;
     ioctl(pty_fd, TIOCSWINSZ, &ws);
@@ -490,14 +490,14 @@ static void qe_term_init(ShellState *s)
 static void qe_term_write(ShellState *s, const char *buf, int len)
 {
     if (len < 0)
-        len = strlen(buf);
+        len = (int)strlen(buf);
 
     if (s->base.qs->trace_buffer)
         qe_trace_bytes(s->base.qs, buf, len, EB_TRACE_PTY);
 
     /* Use bounded timeout to avoid busy-looping on EAGAIN when the
      * PTY buffer is full (child process hung or suspended). */
-    ssize_t written = qe_write_timeout(s->pty_fd, buf, len, 5000);
+    ssize_t written = qe_write_timeout(s->pty_fd, buf, (size_t)len, 5000);
     if (written > 0)
         s->last_char = buf[written - 1];
 }
@@ -1041,12 +1041,12 @@ static int qe_term_insert_lines(ShellState *s, int offset, int n)
 #if QE_TERM_FG_COLORS < 256
 #define MAP_FG_COLOR(color)  qe_map_color(xterm_colors[color], xterm_colors, QE_TERM_FG_COLORS, NULL)
 #else
-#define MAP_FG_COLOR(color)  (color)
+#define MAP_FG_COLOR(color)  (unsigned int)(color)
 #endif
 #if QE_TERM_BG_COLORS < 256
 #define MAP_BG_COLOR(color)  qe_map_color(xterm_colors[color], xterm_colors, QE_TERM_BG_COLORS, NULL)
 #else
-#define MAP_BG_COLOR(color)  (color)
+#define MAP_BG_COLOR(color)  (unsigned int)(color)
 #endif
 
 static int qe_term_csi_m(ShellState *s, const int *params, int count)
@@ -1113,16 +1113,16 @@ static int qe_term_csi_m(ShellState *s, const int *params, int count)
     case 21:    /* Doubly-underlined (ISO 6429). Bold off sometimes */
         goto unhandled;
     case 22:    /* Normal (neither bold nor faint). [exit_bold_mode] */
-        s->attr &= ~QE_TERM_BOLD;
+        s->attr &= ~(unsigned int)QE_TERM_BOLD;
         break;
     case 23:    /* Not italicized (ISO 6429). Not Fraktur. [exit_italic_mode] */
-        s->attr &= ~QE_TERM_ITALIC;
+        s->attr &= ~(unsigned int)QE_TERM_ITALIC;
         break;
     case 24:    /* Not underlined. [exit_underline_mode] */
-        s->attr &= ~QE_TERM_UNDERLINE;
+        s->attr &= ~(unsigned int)QE_TERM_UNDERLINE;
         break;
     case 25:    /* Steady (not blinking). [exit_blink_mode] */
-        s->attr &= ~QE_TERM_BLINK;
+        s->attr &= ~(unsigned int)QE_TERM_BLINK;
         break;
     case 26:    /* reserved */
         goto unhandled;
@@ -1319,8 +1319,8 @@ static void shell_display_hook(EditState *e)
                 }
                 if (s->pty_fd > 0) {
                     struct winsize ws;
-                    ws.ws_col = s->cols;
-                    ws.ws_row = s->rows;
+                    ws.ws_col = (uint16_t)s->cols;
+                    ws.ws_row = (uint16_t)s->rows;
                     ws.ws_xpixel = ws.ws_col;
                     ws.ws_ypixel = ws.ws_row;
                     ioctl(s->pty_fd, TIOCSWINSZ, &ws);
@@ -1381,12 +1381,12 @@ static void shell_key(void *opaque, int key)
     case KEY_F20:       p = s->kf20;  break;
     default:
         if (key < 256) {
-            buf[0] = key;
+            buf[0] = (char)key;
             len = 1;
         } else
         if (key >= KEY_META(0) && key <= KEY_META(255)) {
             buf[0] = '\033';
-            buf[1] = key;
+            buf[1] = (char)key;
             len = 2;
         } else {
             p = NULL;
@@ -1415,7 +1415,7 @@ static void qe_term_emulate(ShellState *s, int c)
     }
     if (s->term_pos < countof(s->term_buf)) {
         /* UTF-8 bytes are appended here (among other uses of the buffer) */
-        s->term_buf[s->term_pos++] = c;
+        s->term_buf[s->term_pos++] = (unsigned char)c;
         s->term_len = s->term_pos;
     }
 
@@ -1555,8 +1555,9 @@ static void qe_term_emulate(ShellState *s, int c)
                             0x2502, 0x2264, 0x2265, 0x03c0,
                             0x2260, 0x00a3, 0x00b7, 0x0020
                         };
-                        s->lastc = c = unitab_xterm_std[c - 96];
-                        len = utf8_encode(buf1, c);
+                        c = (int)unitab_xterm_std[c - 96];
+                        s->lastc = (char32_t)c;
+                        len = utf8_encode(buf1, (char32_t)c);
                     } else {
                         /* CG: quick 8 bit hack: store line drawing
                          * characters in [96..127] as meta control
@@ -1564,7 +1565,8 @@ static void qe_term_emulate(ShellState *s, int c)
                          * This hack is reversed in tty_term_flush().
                          */
                         c += 32;
-                        buf1[0] = s->lastc = c;
+                        s->lastc = (char32_t)c;
+                        buf1[0] = (char)c;
                         len = 1;
                     }
                 } else {
@@ -1586,7 +1588,8 @@ static void qe_term_emulate(ShellState *s, int c)
                         }
                     }
                     //len = eb_encode_char32(s->b, buf1, c);
-                    buf1[0] = s->lastc = c;
+                    s->lastc = (char32_t)c;
+                    buf1[0] = (char)c;
                     len = 1;
                 }
                 s->cur_offset = qe_term_overwrite(s, offset, 1, buf1, len);
@@ -1819,7 +1822,7 @@ static void qe_term_emulate(ShellState *s, int c)
         /* Stop string on \a (^G) or ST (ESC \) */
         if (!(c == '\007' || c == 0234 || (s->lastc == 27 && c == '\\'))) {
             /* XXX: should store the string for specific cases */
-            s->lastc = c;
+            s->lastc = (char32_t)c;
             break;
         }
         s->state = QE_TERM_STATE_NORM;
@@ -1840,7 +1843,7 @@ static void qe_term_emulate(ShellState *s, int c)
             case 7:   /* OSC 7: Current Working Directory */
                 /* Format: file://hostname/path or file:///path */
                 if (slen > 7 && !memcmp(str, "file://", 7)) {
-                    const char *path = memchr(str + 7, '/', slen - 7);
+                    const char *path = memchr(str + 7, '/', (size_t)(slen - 7));
                     if (path) {
                         int pathlen = slen - (int)(path - str);
                         pstrncpy(s->curpath, sizeof(s->curpath), path, pathlen);
@@ -1902,7 +1905,7 @@ static void qe_term_emulate(ShellState *s, int c)
             s->esc1 = c;    /* no need to distinguish leader and interm bytes */
             break;
         }
-        if (qe_isdigit(c)) {
+        if (qe_isdigit((char32_t)c)) {
             s->params[s->nb_params] &= ~CSI_PARAM_OMITTED;
             s->params[s->nb_params] *= 10;
             s->params[s->nb_params] += c - '0';
@@ -2468,7 +2471,7 @@ static void shell_read_cb(void *opaque)
     if (!s || s->base.mode != &shell_mode)
         return;
 
-    len = read(s->pty_fd, buf, sizeof(buf));
+    len = (int)read(s->pty_fd, buf, sizeof(buf));
     if (len <= 0) {
         if (len == 0 || (errno != EAGAIN && errno != EINTR)) {
             /* EOF or fatal error (e.g. EIO when slave pty closed):
@@ -2618,7 +2621,7 @@ static void shell_pid_cb(void *opaque, int status)
         int save_readonly = s->b->flags & BF_READONLY;
         s->b->flags &= ~BF_READONLY;
 
-        eb_write(b, b->total_size, buf, strlen(buf));
+        eb_write(b, b->total_size, buf, (int)strlen(buf));
 
         if (save_readonly) {
             s->b->modified = 0;
@@ -3044,10 +3047,10 @@ static void shell_write_char(EditState *e, int c)
 
         if (c >= KEY_META(0) && c <= KEY_META(0xff)) {
             buf[0] = '\033';
-            buf[1] = c - KEY_META(0);
+            buf[1] = (char)(c - KEY_META(0));
             len = 2;
         } else {
-            len = eb_encode_char32(e->b, buf, c);
+            len = eb_encode_char32(e->b, buf, (char32_t)c);
         }
         qe_term_write(s, buf, len);
     } else {
@@ -3290,7 +3293,7 @@ static void do_shell_yank(EditState *e)
                 if (c == '\n')
                     do_shell_newline(e);
                 else
-                    shell_write_char(e, c);
+                    shell_write_char(e, (int)c);
             }
         }
         qs->this_cmd_func = (CmdFunc)do_yank;
@@ -3355,8 +3358,8 @@ static void do_shell_refresh(EditState *e, int flags)
 
         if (s->pty_fd > 0 && (flags & SR_UPDATE_SIZE)) {
             struct winsize ws;
-            ws.ws_col = s->cols;
-            ws.ws_row = s->rows;
+            ws.ws_col = (uint16_t)s->cols;
+            ws.ws_row = (uint16_t)s->rows;
             ws.ws_xpixel = ws.ws_col;
             ws.ws_ypixel = ws.ws_row;
             ioctl(s->pty_fd, TIOCSWINSZ, &ws);
@@ -3586,7 +3589,7 @@ static void do_next_error(EditState *s, int arg, int dir)
                 break;
             if (!qe_isdigit(c))
                 goto next_line;
-            line_num = line_num * 10 + c - '0';
+            line_num = line_num * 10 + (int)(c - '0');
         }
         if (c == ':' || c == ',' || c == '.') {
             int offset0 = offset;
@@ -3596,7 +3599,7 @@ static void do_next_error(EditState *s, int arg, int dir)
                 if (c == ' ') continue;
                 if (!qe_isdigit(c))
                     break;
-                col_num = col_num * 10 + c - '0';
+                col_num = col_num * 10 + (int)(c - '0');
             }
             if (col_num == 0) {
                 offset = offset0;
@@ -3691,7 +3694,7 @@ static int shell_grab_filename(const char32_t *buf, int n,
             continue;
         }
         if (len + 1 < size) {
-            dest[len++] = c;
+            dest[len++] = (char)c;
         }
     }
     if (size)

--- a/modes/unihex.c
+++ b/modes/unihex.c
@@ -64,7 +64,7 @@ static int unihex_to_disp(char32_t c) {
     if (c < ' ' || c == 127 || (c >= 128 && c < 160)
     ||  (c >= 0xD800 && c <= 0xDFFF) || c > 0x10FFFF)
         c = '.';
-    return c;
+    return (int)c;
 }
 
 static int unihex_backward_offset(EditState *s, int offset)
@@ -84,7 +84,7 @@ static int unihex_display_line(EditState *s, DisplayState *ds, int offset)
     char32_t c, maxc, b;
     /* CG: array size is incorrect, should be smaller */
     char32_t buf[LINE_MAX_SIZE];
-    char32_t pos[LINE_MAX_SIZE];
+    int pos[LINE_MAX_SIZE];
 
     display_bol(ds);
 
@@ -148,7 +148,7 @@ static int unihex_display_line(EditState *s, DisplayState *ds, int offset)
         offset2 = pos[j + 1];
         if (j < len) {
             b = buf[j];
-            b = unihex_to_disp(b);
+            b = (char32_t)(unsigned int)unihex_to_disp(b);
         } else {
             b = ' ';
             if (!ateof) {

--- a/plugin.c
+++ b/plugin.c
@@ -58,10 +58,10 @@ int qe_lua_eval(lua_State *L, const char *code, char *errbuf, int errsize)
         if (errbuf && errsize > 0) {
             const char *msg = lua_tostring(L, -1);
             if (msg) {
-                int len = strlen(msg);
+                int len = (int)strlen(msg);
                 if (len >= errsize)
                     len = errsize - 1;
-                memcpy(errbuf, msg, len);
+                memcpy(errbuf, msg, (size_t)len);
                 errbuf[len] = '\0';
             }
         }
@@ -88,10 +88,10 @@ int qe_lua_load_config(lua_State *L, const char *filename,
         if (errbuf && errsize > 0) {
             const char *msg = lua_tostring(L, -1);
             if (msg) {
-                int len = strlen(msg);
+                int len = (int)strlen(msg);
                 if (len >= errsize)
                     len = errsize - 1;
-                memcpy(errbuf, msg, len);
+                memcpy(errbuf, msg, (size_t)len);
                 errbuf[len] = '\0';
             }
         }
@@ -121,10 +121,10 @@ int qe_lua_eval_expression(lua_State *L, const char *code,
         if (errbuf && errsize > 0) {
             const char *msg = lua_tostring(L, -1);
             if (msg) {
-                int len = strlen(msg);
+                int len = (int)strlen(msg);
                 if (len >= errsize)
                     len = errsize - 1;
-                memcpy(errbuf, msg, len);
+                memcpy(errbuf, msg, (size_t)len);
                 errbuf[len] = '\0';
             }
         }
@@ -136,10 +136,10 @@ int qe_lua_eval_expression(lua_State *L, const char *code,
     if (result && resultsize > 0 && !lua_isnoneornil(L, -1)) {
         const char *s = luaL_tolstring(L, -1, NULL);
         if (s) {
-            int len = strlen(s);
+            int len = (int)strlen(s);
             if (len >= resultsize)
                 len = resultsize - 1;
-            memcpy(result, s, len);
+            memcpy(result, s, (size_t)len);
             result[len] = '\0';
         }
         lua_pop(L, 1); /* pop tolstring result */
@@ -186,7 +186,7 @@ static int l_delete(lua_State *L)
     int n;
 
     if (!s) return 0;
-    n = luaL_checkinteger(L, 1);
+    n = (int)luaL_checkinteger(L, 1);
     if (n > 0 && s->offset + n <= s->b->total_size)
         eb_delete(s->b, s->offset, n);
     return 0;
@@ -207,7 +207,7 @@ static int l_set_point(lua_State *L)
     int offset;
 
     if (!s) return 0;
-    offset = luaL_checkinteger(L, 1);
+    offset = (int)luaL_checkinteger(L, 1);
     if (offset < 0) offset = 0;
     if (offset > s->b->total_size) offset = s->b->total_size;
     s->offset = offset;
@@ -297,8 +297,8 @@ static int l_goto_line(lua_State *L)
     int line, col;
 
     if (!s) return 0;
-    line = luaL_checkinteger(L, 1) - 1;  /* convert to 0-based */
-    col = luaL_optinteger(L, 2, 0);
+    line = (int)luaL_checkinteger(L, 1) - 1;  /* convert to 0-based */
+    col = (int)luaL_optinteger(L, 2, 0);
     s->offset = eb_goto_pos(s->b, line, col);
     return 0;
 }
@@ -309,35 +309,36 @@ static int l_char_at(lua_State *L)
     EditState *s = lua_get_active_state();
     int offset;
     char buf[8];
-    int ch, len;
+    char32_t ch;
+    int len;
 
     if (!s) { lua_pushstring(L, ""); return 1; }
-    offset = luaL_optinteger(L, 1, s->offset);
+    offset = (int)luaL_optinteger(L, 1, s->offset);
     ch = eb_nextc(s->b, offset, &offset);
-    if (ch == EOF) {
+    if (ch == (char32_t)EOF) {
         lua_pushstring(L, "");
     } else {
         /* encode as UTF-8 */
         if (ch < 0x80) {
-            buf[0] = ch;
+            buf[0] = (char)ch;
             len = 1;
         } else if (ch < 0x800) {
-            buf[0] = 0xC0 | (ch >> 6);
-            buf[1] = 0x80 | (ch & 0x3F);
+            buf[0] = (char)(0xC0 | (ch >> 6));
+            buf[1] = (char)(0x80 | (ch & 0x3F));
             len = 2;
         } else if (ch < 0x10000) {
-            buf[0] = 0xE0 | (ch >> 12);
-            buf[1] = 0x80 | ((ch >> 6) & 0x3F);
-            buf[2] = 0x80 | (ch & 0x3F);
+            buf[0] = (char)(0xE0 | (ch >> 12));
+            buf[1] = (char)(0x80 | ((ch >> 6) & 0x3F));
+            buf[2] = (char)(0x80 | (ch & 0x3F));
             len = 3;
         } else {
-            buf[0] = 0xF0 | (ch >> 18);
-            buf[1] = 0x80 | ((ch >> 12) & 0x3F);
-            buf[2] = 0x80 | ((ch >> 6) & 0x3F);
-            buf[3] = 0x80 | (ch & 0x3F);
+            buf[0] = (char)(0xF0 | (ch >> 18));
+            buf[1] = (char)(0x80 | ((ch >> 12) & 0x3F));
+            buf[2] = (char)(0x80 | ((ch >> 6) & 0x3F));
+            buf[3] = (char)(0x80 | (ch & 0x3F));
             len = 4;
         }
-        lua_pushlstring(L, buf, len);
+        lua_pushlstring(L, buf, (size_t)len);
     }
     return 1;
 }
@@ -350,8 +351,8 @@ static int l_region_text(lua_State *L)
     char *buf;
 
     if (!s) { lua_pushstring(L, ""); return 1; }
-    start = luaL_checkinteger(L, 1);
-    stop = luaL_checkinteger(L, 2);
+    start = (int)luaL_checkinteger(L, 1);
+    stop = (int)luaL_checkinteger(L, 2);
     if (start < 0) start = 0;
     if (stop > s->b->total_size) stop = s->b->total_size;
     if (stop <= start) { lua_pushstring(L, ""); return 1; }
@@ -360,7 +361,7 @@ static int l_region_text(lua_State *L)
     if (!buf) { lua_pushstring(L, ""); return 1; }
     eb_read(s->b, start, buf, size);
     buf[size] = '\0';
-    lua_pushlstring(L, buf, size);
+    lua_pushlstring(L, buf, (size_t)size);
     qe_free(&buf);
     return 1;
 }
@@ -454,15 +455,15 @@ static int l_command(lua_State *L)
 
     /* Build the name\0binding\0 storage (CmdDef.name format) */
     storage = lua_cmd_storage[nb_lua_cmds];
-    name_len = strlen(name);
-    binding_len = strlen(binding);
+    name_len = (int)strlen(name);
+    binding_len = (int)strlen(binding);
     if (name_len + 1 + binding_len + 1 > (int)sizeof(lua_cmd_storage[0])) {
         luaL_unref(L, LUA_REGISTRYINDEX, ref);
         return luaL_error(L, "command name + binding too long");
     }
-    memcpy(storage, name, name_len);
+    memcpy(storage, name, (size_t)name_len);
     storage[name_len] = '\0';
-    memcpy(storage + name_len + 1, binding, binding_len);
+    memcpy(storage + name_len + 1, binding, (size_t)binding_len);
     storage[name_len + 1 + binding_len] = '\0';
 
     /* Build CmdDef */
@@ -471,7 +472,10 @@ static int l_command(lua_State *L)
     lua_cmd_specs[nb_lua_cmds][0] = '\0';
     cmd->spec = lua_cmd_specs[nb_lua_cmds];
     cmd->sig = CMD_ESi;
-    cmd->val = ref;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+    cmd->val = ref;  /* Lua registry ref; fits in 24 bits in practice */
+#pragma GCC diagnostic pop
     cmd->action.ESi = (void (*)(EditState *, int))lua_cmd_dispatch;
 
     qe_register_commands(lua_qs, NULL, cmd, 1);

--- a/qe.c
+++ b/qe.c
@@ -196,7 +196,7 @@ void qe_register_mode(QEmacsState *qs, ModeDef *m, int flags)
         /* lower case convert for C mode, Perl... */
         qe_strtolower(name, sizeof(name) - 10, mode_name);
         pstrcat(name, sizeof(name), "-mode");
-        name_len = strlen(name);
+        name_len = (int)strlen(name);
         name[name_len + 1] = '\0'; /* empty default bindings string */
 
         /* Achtung: embedded null bytes */
@@ -205,8 +205,8 @@ void qe_register_mode(QEmacsState *qs, ModeDef *m, int flags)
                             mode_name, 0, mode_name);
         def = qe_mallocz(CmdDef);
         /* allocate space for name and spec with embedded null bytes */
-        def->name = qe_malloc_dup_bytes(name, name_len + 2);
-        def->spec = qe_malloc_dup_bytes(spec, spec_len + 1);
+        def->name = qe_malloc_dup_bytes(name, (size_t)(name_len + 2));
+        def->spec = qe_malloc_dup_bytes(spec, (size_t)(spec_len + 1));
         def->sig = CMD_ESs;
         def->val = 0;
         def->action.ESs = do_set_mode;
@@ -306,7 +306,7 @@ int command_get_entry(EditState *s, char *dest, int size, int offset)
 {
     int len;
     eb_fgets(s->b, dest, size, offset, &offset);
-    len = strcspn(dest, " \t\n(");
+    len = (int)strcspn(dest, " \t\n(");
     dest[len] = '\0';   /* strip the TAB or trailing newline if any */
     return len;
 }
@@ -339,7 +339,7 @@ static int qe_register_binding(KeyDef **lp, const CmdDef *d, const unsigned int 
         return -1;
 
     /* add key */
-    p = qe_malloc_hack(KeyDef, (nb_keys - 1) * sizeof(p->keys[0]));
+    p = qe_malloc_hack(KeyDef, (size_t)(nb_keys - 1) * sizeof(p->keys[0]));
     if (!p)
         return -1;
     p->cmd = d;
@@ -718,14 +718,14 @@ static void color_complete(CompleteState *cp, CompleteFunc enumerate) {
     int i, len;
 
     if (*name == '#') {
-        for (len = 0; qe_isxdigit(name[1 + len]); len++)
+        for (len = 0; qe_isxdigit((unsigned char)name[1 + len]); len++)
             continue;
         if (len > 2 && len <= 6) {
-            QEColor rgb = strtol_c(name + 1, NULL, 16);
+            QEColor rgb = (QEColor)strtol_c(name + 1, NULL, 16);
             int shift = (6 - len) * 4;
             rgb <<= shift;
             for (i = 0; i < (0x1 << shift); i++) {
-                snprintf(buf, sizeof buf, "#%06x", rgb + i);
+                snprintf(buf, sizeof buf, "#%06x", rgb + (unsigned int)i);
                 enumerate(cp, buf, CT_GLOB);
             }
         } else {
@@ -743,7 +743,7 @@ static void color_complete(CompleteState *cp, CompleteFunc enumerate) {
             def++;
             count--;
         }
-        if (name[0] == 'p' && !qe_isalpha(name[1])) {
+        if (name[0] == 'p' && !qe_isalpha((unsigned char)name[1])) {
             for (i = 0; i < 8192; i++) {
                 snprintf(buf, sizeof buf, "p%d", i);
                 enumerate(cp, buf, CT_GLOB);
@@ -1721,9 +1721,9 @@ void text_mouse_goto(EditState *s, int x, int y, QEEvent *ev)
             /* always include the character under the mouse pointer,
              * extend to the end of the word it is a word character
              */
-            if (qe_isword(eb_peekc(s->b, start)))
+            if (qe_isword((unsigned int)eb_peekc(s->b, start)))
                 start = eb_word_left(s->b, 0, start);
-            if (qe_isword(eb_peekc(s->b, stop)))
+            if (qe_isword((unsigned int)eb_peekc(s->b, stop)))
                 stop = eb_word_right(s->b, 0, stop);
             else
                 stop = eb_next(s->b, stop);
@@ -1804,7 +1804,7 @@ void do_char(EditState *s, int key, int argval) {
         const char *p;
         if (key < 255 && (p = strchr(pairs, key)) != NULL) {
             while (repeat --> 0) {
-                int index = (p - pairs) & ~1;
+                int index = (int)(p - pairs) & ~1;
                 const char *p1 = &pairs[index + (s->b->mark > s->offset)];
                 const char *p2 = &pairs[index + (s->b->mark < s->offset)];
                 eb_insert(s->b, s->b->mark, p1, 1);
@@ -1828,7 +1828,7 @@ void do_combine_accent(EditState *s, int accent_arg) {
     int offset0, len;
     char32_t g[2];
     char buf[MAX_CHAR_BYTES];
-    char32_t c, accent = accent_arg;
+    char32_t c, accent = (char32_t)accent_arg;
 
     if (s->b->flags & BF_READONLY)
         return;
@@ -1851,7 +1851,7 @@ void do_combine_accent(EditState *s, int accent_arg) {
         offset0 += eb_replace(s->b, offset0, s->offset - offset0, buf, len);
         s->offset = offset0;
     } else {
-        do_char(s, accent, 1);
+        do_char(s, (int)accent, 1);
     }
 }
 #endif
@@ -1891,9 +1891,9 @@ void text_write_char(EditState *s, int key)
     s->region_style = 0;
 
     cur_ch = eb_nextc(s->b, s->offset, &endpos);
-    len = eb_encode_char32(s->b, buf, key);
+    len = eb_encode_char32(s->b, buf, (char32_t)key);
     insert = (!s->overwrite || cur_ch == '\n' ||
-              key == '\t' ||  key == '\n' || qe_isaccent(key));
+              key == '\t' ||  key == '\n' || qe_isaccent((unsigned int)key));
 
     if (insert) {
         const InputMethod *m;
@@ -1912,7 +1912,7 @@ void text_write_char(EditState *s, int key)
         /* insert char */
         s->offset += eb_insert(s->b, s->offset, buf, len);
 
-        s->compose_buf[s->compose_len++] = key;
+        s->compose_buf[s->compose_len++] = (char32_t)key;
         m = s->input_method;
         for (;;) {
             if (!m) {
@@ -1936,11 +1936,11 @@ void text_write_char(EditState *s, int key)
                 eb_delete_range(s->b, s->compose_start_offset, offset);
                 s->compose_len -= match_len;
                 umemmove(s->compose_buf, s->compose_buf + match_len,
-                         s->compose_len);
+                         (size_t)s->compose_len);
                 /* then insert match */
                 for (i = 0; i < ret; i++) {
                     key = match_buf[i];
-                    len = eb_encode_char32(s->b, buf, key);
+                    len = eb_encode_char32(s->b, buf, (char32_t)key);
                     eb_insert(s->b, s->compose_start_offset, buf, len);
                     s->compose_start_offset += len;
                     /* should only bump s->offset if at insert point */
@@ -1954,7 +1954,7 @@ void text_write_char(EditState *s, int key)
     } else {
         int w, w1, offset2;
 
-        w = qe_wcwidth(key);
+        w = qe_wcwidth((char32_t)key);
         if (cur_ch == '\t') {
             int tw = s->b->tab_width > 0 ? s->b->tab_width : 8;
             int col = text_screen_width(s->b, eb_goto_bol(s->b, s->offset), s->offset, tw);
@@ -2623,7 +2623,7 @@ static int reload_buffer(EditState *s, EditBuffer *b)
 QEModeData *qe_create_buffer_mode_data(EditBuffer *b, ModeDef *m)
 {
     QEModeData *md = NULL;
-    int size = m->buffer_instance_size - sizeof(QEModeData);
+    int size = m->buffer_instance_size - (int)sizeof(QEModeData);
 
     if (size >= 0) {
         md = qe_mallocz_hack(QEModeData, size);
@@ -2659,7 +2659,7 @@ void *qe_get_buffer_mode_data(EditBuffer *b, ModeDef *m, EditState *e)
 QEModeData *qe_create_window_mode_data(EditState *s, ModeDef *m)
 {
     QEModeData *md = NULL;
-    int size = m->window_instance_size - sizeof(QEModeData);
+    int size = m->window_instance_size - (int)sizeof(QEModeData);
 
     if (!s->mode_data && size >= 0) {
         md = qe_mallocz_hack(QEModeData, size);
@@ -3073,7 +3073,7 @@ void do_goto(EditState *s, const char *str, int unit)
      * CG: XXX: resulting offset may fall inside a character.
      */
     rel = (*str == '+' || *str == '-');
-    pos = strtol_c(str, &p, 0);
+    pos = (int)strtol_c(str, &p, 0);
 
     /* skip space required to separate hex offset from b or c suffix */
     if (*p == ' ')
@@ -3126,7 +3126,7 @@ void do_goto(EditState *s, const char *str, int unit)
         return;
     case '%':
         /* CG: should not require long long for this */
-        pos = pos * (long long)s->b->total_size / 100;
+        pos = (int)((long long)pos * s->b->total_size / 100);
         if (rel)
             pos += s->offset;
         eb_get_pos(s->b, &line, &col, clamp_offset(pos, 0, s->b->total_size));
@@ -3142,7 +3142,7 @@ void do_goto(EditState *s, const char *str, int unit)
     getcol:
         col = 0;
         if (*p == ':' || *p == '.') {
-            col = strtol_c(p + 1, &p, 0);
+            col = (int)strtol_c(p + 1, &p, 0);
             col -= (col > 0);  // user column numbers are 1-based
         }
         if (*p)
@@ -3234,7 +3234,7 @@ void do_what_cursor_position(EditState *s)
             int sep = '[';
             buf_put_byte(out, ' ');
             for (off = s->offset; off < offset1; off++) {
-                cc = eb_read_one_byte(s->b, off);
+                cc = (char32_t)eb_read_one_byte(s->b, off);
                 buf_printf(out, "%c%02X", sep, cc);
                 sep = ' ';
             }
@@ -3509,7 +3509,7 @@ void display_window_borders(EditState *e)
                         int len;
 
                         for (len = 0; len < 256 && e->caption[len]; len++) {
-                            buf[len] = e->caption[len];
+                            buf[len] = (unsigned char)e->caption[len];
                         }
                         get_style(e, &styledef, QE_STYLE_WINDOW_BORDER);
                         font = select_font(qs->screen,
@@ -3559,10 +3559,10 @@ void fill_window_slack(EditState *s, int x, int y, int w, int h, int color)
     h1 = max_int(0, y);
     h2 = max_int(0, h0 - (y + h));
 
-    if (w1) fill_rectangle(s->screen, x0, y0, w1, h0, color);
-    if (w2) fill_rectangle(s->screen, x0 + w0 - w2, y0, w2, h0, color);
-    if (h1) fill_rectangle(s->screen, x0 + w1, y0, w0 - w1 - w2, h1, color);
-    if (h2) fill_rectangle(s->screen, x0 + w1, y0 + h0 - h2, w0 - w1 - w2, h2, color);
+    if (w1) fill_rectangle(s->screen, x0, y0, w1, h0, (QEColor)color);
+    if (w2) fill_rectangle(s->screen, x0 + w0 - w2, y0, w2, h0, (QEColor)color);
+    if (h1) fill_rectangle(s->screen, x0 + w1, y0, w0 - w1 - w2, h1, (QEColor)color);
+    if (h2) fill_rectangle(s->screen, x0 + w1, y0 + h0 - h2, w0 - w1 - w2, h2, (QEColor)color);
 }
 
 #if 1
@@ -3646,8 +3646,8 @@ int find_style_index(const char *name)
         if (strequal(stp->name, name))
             return i;
     }
-    if (qe_isdigit(*name)) {
-        i = strtol(name, NULL, 0);
+    if (qe_isdigit((unsigned char)*name)) {
+        i = (int)strtol(name, NULL, 0);
         if (i < QE_STYLE_NB)
             return i;
     }
@@ -3747,7 +3747,7 @@ void do_set_style(EditState *e, const char *stylestr,
         return;
     case CSS_PROP_FONT_FAMILY:
         v = css_get_font_family(value);
-        stp->font_style = (stp->font_style & ~QE_FONT_FAMILY_MASK) | v;
+        stp->font_style = (short)((stp->font_style & ~QE_FONT_FAMILY_MASK) | v);
         break;
     case CSS_PROP_FONT_STYLE:
         /* XXX: cannot handle inherit correctly */
@@ -3758,7 +3758,7 @@ void do_set_style(EditState *e, const char *stylestr,
         if (strequal(value, "normal")) {
             v &= ~QE_FONT_STYLE_ITALIC;
         }
-        stp->font_style = v;
+        stp->font_style = (short)v;
         break;
     case CSS_PROP_FONT_WEIGHT:
         /* XXX: cannot handle inherit correctly */
@@ -3769,13 +3769,13 @@ void do_set_style(EditState *e, const char *stylestr,
         if (strequal(value, "normal")) {
             v &= ~QE_FONT_STYLE_BOLD;
         }
-        stp->font_style = v;
+        stp->font_style = (short)v;
         break;
     case CSS_PROP_FONT_SIZE:
         if (strequal(value, "inherit")) {
             stp->font_size = 0;
         } else {
-            stp->font_size = strtol(value, NULL, 0);
+            stp->font_size = (short)strtol(value, NULL, 0);
         }
         break;
     case CSS_PROP_TEXT_DECORATION:
@@ -3836,7 +3836,7 @@ void do_set_window_style(EditState *s, const char *stylestr)
         put_error(s, "Unknown style '%s'", stylestr);
         return;
     }
-    s->default_style = style_index;
+    s->default_style = (QETermStyle)style_index;
 }
 
 void do_set_system_font(EditState *s, const char *qe_font_name,
@@ -4069,7 +4069,7 @@ static void flush_line(DisplayState *ds,
                 if (qe_realloc_array(&e->line_shadow, n)) {
                     /* put an impossible value so that we redraw */
                     memset(&e->line_shadow[e->shadow_nb_lines], 0xff,
-                           (n - e->shadow_nb_lines) * sizeof(QELineShadow));
+                           (size_t)(n - e->shadow_nb_lines) * sizeof(QELineShadow));
                     e->shadow_nb_lines = n;
                 }
             }
@@ -4077,8 +4077,8 @@ static void flush_line(DisplayState *ds,
                 QELineShadow *ls;
                 uint64_t crc;
 
-                crc = compute_crc(fragments, sizeof(*fragments) * nb_fragments, 0);
-                crc = compute_crc(ds->line_chars, sizeof(*ds->line_chars) * ds->line_index, crc);
+                crc = compute_crc(fragments, sizeof(*fragments) * (size_t)nb_fragments, 0);
+                crc = compute_crc(ds->line_chars, sizeof(*ds->line_chars) * (size_t)ds->line_index, crc);
                 /* Include the EOL style in the CRC so that BCE background
                  * color changes (from \e[K with a colored background) cause
                  * the line to be redrawn.
@@ -4088,9 +4088,9 @@ static void flush_line(DisplayState *ds,
                 if (ls->y != ds->y || ls->x != ds->x_line
                 ||  ls->height != line_height || ls->crc != crc) {
                     /* update values for the line cache */
-                    ls->y = ds->y;
+                    ls->y = (short)ds->y;
                     ls->x = ds->x_line;
-                    ls->height = line_height;
+                    ls->height = (short)line_height;
                     ls->crc = crc;
                 } else {
                     no_display = 1;
@@ -4332,7 +4332,7 @@ static void flush_fragment(DisplayState *ds)
     }
     for (i = 0; i < ds->fragment_index; i++) {
         int offset1, offset2;
-        j = ds->line_index + char_to_glyph_pos[i];
+        j = ds->line_index + (int)char_to_glyph_pos[i];
         offset1 = ds->fragment_offsets[i][0];
         offset2 = ds->fragment_offsets[i][1];
         ds->line_hex_mode[j] = ds->fragment_hex_mode[i];
@@ -4359,7 +4359,7 @@ static void flush_fragment(DisplayState *ds)
         w = ds->tab_width - x1;
         /* display a single space */
         ds->line_chars[j] = ' ';
-        ds->line_char_widths[j] = w;
+        ds->line_char_widths[j] = (short)w;
     } else {
         /* XXX: use text metrics for full fragment */
         w = 0;
@@ -4371,7 +4371,7 @@ static void flush_fragment(DisplayState *ds)
                 ascent = metrics.font_ascent;
             if (metrics.font_descent > descent)
                 descent = metrics.font_descent;
-            ds->line_char_widths[j] = metrics.width;
+            ds->line_char_widths[j] = (short)metrics.width;
             w += ds->line_char_widths[j];
             j++;
         }
@@ -4380,13 +4380,13 @@ static void flush_fragment(DisplayState *ds)
 
     /* add the fragment */
     frag = &ds->fragments[ds->nb_fragments++];
-    frag->width = w;
-    frag->line_index = ds->line_index;
-    frag->len = nb_glyphs;
-    frag->embedding_level = ds->last_embedding_level;
+    frag->width = (short)w;
+    frag->line_index = (short)ds->line_index;
+    frag->len = (short)nb_glyphs;
+    frag->embedding_level = (unsigned short)ds->last_embedding_level;
     frag->style = style;
-    frag->ascent = ascent;
-    frag->descent = descent;
+    frag->ascent = (short)ascent;
+    frag->descent = (short)descent;
 #if QE_TERM_STYLE_BITS == 16
     frag->dummy = 0;  /* initialize padding for checksum consistency */
 #endif
@@ -4420,8 +4420,8 @@ static void flush_fragment(DisplayState *ds)
             }
             len1 -= len;
             w1 -= ds->x;
-            frag->len = len;
-            frag->width -= w1;
+            frag->len = (short)len;
+            frag->width -= (short)w1;
             //printf("after: x=%d w1=%d\n", ds->x, w1);
             n = ds->nb_fragments;
             if (len == 0)
@@ -4439,9 +4439,9 @@ static void flush_fragment(DisplayState *ds)
             if (len1 > 0) {
                 blockmove(ds->fragments, frag, 1);
                 frag = ds->fragments;
-                frag->width = w1;
+                frag->width = (short)w1;
                 frag->line_index = 0;
-                frag->len = len1;
+                frag->len = (short)len1;
                 ds->nb_fragments = 1;
                 ds->x += w1;
             }
@@ -4466,7 +4466,7 @@ static void flush_fragment(DisplayState *ds)
             ds->nb_fragments -= ds->word_index;
 
             for (i = 0; i < ds->nb_fragments; i++) {
-                ds->fragments[i].line_index -= index;
+                ds->fragments[i].line_index -= (short)index;
                 ds->x += ds->fragments[i].width;
             }
             keep_line_chars(ds, ds->line_index - index);
@@ -4497,7 +4497,7 @@ int display_char_bidir(DisplayState *ds, int offset1, int offset2,
             if (e->show_selection)
                 style |= QE_STYLE_SEL;
             else
-                style = e->region_style;
+                style = (QETermStyle)e->region_style;
         }
     }
     /* special patch for selection in hex mode */
@@ -4529,7 +4529,7 @@ int display_char_bidir(DisplayState *ds, int offset1, int offset2,
                 ds->fragment_chars[ds->fragment_index] = ' ';
                 ds->fragment_offsets[ds->fragment_index][0] = off1;
                 ds->fragment_offsets[ds->fragment_index][1] = off2;
-                ds->fragment_hex_mode[ds->fragment_index] = cur_hex;
+                ds->fragment_hex_mode[ds->fragment_index] = (unsigned char)cur_hex;
                 ds->fragment_index++;
             } else {
                 flush_fragment(ds);
@@ -4542,7 +4542,7 @@ int display_char_bidir(DisplayState *ds, int offset1, int offset2,
         ds->fragment_chars[ds->fragment_index] = ' ';
         ds->fragment_offsets[ds->fragment_index][0] = offset1;
         ds->fragment_offsets[ds->fragment_index][1] = offset2;
-        ds->fragment_hex_mode[ds->fragment_index] = ds->cur_hex_mode;
+        ds->fragment_hex_mode[ds->fragment_index] = (unsigned char)ds->cur_hex_mode;
         ds->fragment_index++;
         offset1 = offset2 = -1;
     }
@@ -4550,7 +4550,7 @@ int display_char_bidir(DisplayState *ds, int offset1, int offset2,
     ds->fragment_chars[ds->fragment_index] = ch;
     ds->fragment_offsets[ds->fragment_index][0] = offset1;
     ds->fragment_offsets[ds->fragment_index][1] = offset2;
-    ds->fragment_hex_mode[ds->fragment_index] = ds->cur_hex_mode;
+    ds->fragment_hex_mode[ds->fragment_index] = (unsigned char)ds->cur_hex_mode;
     ds->fragment_index++;
 
     ds->last_space = space;
@@ -4578,9 +4578,9 @@ void display_printhex(DisplayState *ds, int offset1, int offset2,
             v += '0';
         /* XXX: simplistic */
         if (e->hex_nibble == i) {
-            display_char(ds, offset1, offset2, v);
+            display_char(ds, offset1, offset2, (char32_t)v);
         } else {
-            display_char(ds, offset1, offset1, v);
+            display_char(ds, offset1, offset1, (char32_t)v);
         }
     }
     ds->cur_hex_mode = 0;
@@ -4599,10 +4599,10 @@ void display_printf(DisplayState *ds, int offset1, int offset2,
     p = buf;
     if (*p) {
         /* XXX: UTF-8 unsupported, not needed at this point */
-        display_char(ds, offset1, offset2, *p++);
+        display_char(ds, offset1, offset2, (unsigned char)*p++);
         while (*p) {
             /* XXX: Should make these display character mouse selectable */
-            display_char(ds, -1, -1, *p++);
+            display_char(ds, -1, -1, (unsigned char)*p++);
         }
     }
 }
@@ -4710,7 +4710,7 @@ static int bidir_compute_attributes(BidirTypeLink *list_tab, int max_size,
     p->pos = offset1;
     p++;
 
-    return p - list_tab;
+    return (int)(p - list_tab);
 }
 #endif
 
@@ -4889,7 +4889,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
                 cp->offset = eb_next(b, cp->offset);
             }
             cp_colorize_line(cp, cp->buf, bom, len, cp->sbuf, s->colorize_mode);
-            s->colorize_states[line] = cp->colorize_state;
+            s->colorize_states[line] = (unsigned short)cp->colorize_state;
         }
     }
 
@@ -6391,9 +6391,9 @@ void do_define_kbd_macro(EditState *s, const char *name, const char *keys,
         def->spec = buf;
     } else {
         def = qe_mallocz(CmdDef);
-        name_len = strlen(name);
+        name_len = (int)strlen(name);
         /* allocate space for name and extra NUL for no bindings */
-        def->name = memcpy(qe_mallocz_bytes(name_len + 2), name, name_len);
+        def->name = memcpy(qe_mallocz_bytes((size_t)(name_len + 2)), name, (size_t)name_len);
         def->spec = buf;
         def->sig = CMD_ESs;
         def->val = 0;

--- a/qe.c
+++ b/qe.c
@@ -4914,7 +4914,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
             offset1 = eb_next(b, offset1);
     }
 
-    memset(cp->sbuf, 0, (len + 1) * sizeof(*cp->sbuf));
+    memset(cp->sbuf, 0, (size_t)(len + 1) * sizeof(*cp->sbuf));
     bom = (cp->buf[0] == 0xFEFF);
     if (bom) {
         SET_STYLE1(cp->sbuf, 0, QE_STYLE_PREPROCESS);
@@ -4928,7 +4928,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
     //cp->buf[len + 1] = 0;
 
     /* XXX: if state is same as previous, minimize invalid region? */
-    s->colorize_states[line_num + 1] = cp->colorize_state;
+    s->colorize_states[line_num + 1] = (unsigned short)cp->colorize_state;
 
     /* Extend valid area */
     if (s->colorize_nb_valid_lines < line_num + 2)
@@ -5022,7 +5022,7 @@ int get_colorized_line(QEColorizeContext *cp,
         }
         cp->buf[len] = '\0';
         if (cp->sbuf) {
-            memset(cp->sbuf, 0, (len + 1) * sizeof(*cp->sbuf));
+            memset(cp->sbuf, 0, (size_t)(len + 1) * sizeof(*cp->sbuf));
         }
     }
     // XXX: should test if TABs should be colorized too
@@ -5119,7 +5119,7 @@ int text_display_line(EditState *s, DisplayState *ds, int offset)
                     if (cp->buf[i] == ']') {
                         level--;
                     } else
-                    if (level == 0 || !(cp->sbuf[i] & ~QE_STYLE_NUM)) {
+                    if (level == 0 || !(cp->sbuf[i] & ~(QETermStyle)QE_STYLE_NUM)) {
                         cp->sbuf[i] = QE_STYLE_HIGHLIGHT;
                     }
                 }
@@ -5161,7 +5161,7 @@ int text_display_line(EditState *s, DisplayState *ds, int offset)
                     eb_get_pos(s->b, &line, &end_char, end_offset);
 
                 for (i = start_char; i < end_char; i++) {
-                    cp->sbuf[i] = s->region_style;
+                    cp->sbuf[i] = (QETermStyle)s->region_style;
                 }
             }
         } else
@@ -5169,7 +5169,7 @@ int text_display_line(EditState *s, DisplayState *ds, int offset)
             /* XXX: only if qs->active_window == s ? */
             int i;
             for (i = 0; i < colored_nb_chars; i++)
-                cp->sbuf[i] = s->curline_style;
+                cp->sbuf[i] = (QETermStyle)s->curline_style;
         }
     }
 #endif
@@ -5386,7 +5386,7 @@ static void generic_text_display(EditState *s)
         if (ds->line_num >= 0 && ds->line_num < s->shadow_nb_lines) {
             /* erase the line shadow for the rest of the window */
             memset(&s->line_shadow[ds->line_num], 0xff,
-                   (s->shadow_nb_lines - ds->line_num) * sizeof(QELineShadow));
+                   (size_t)(s->shadow_nb_lines - ds->line_num) * sizeof(QELineShadow));
         }
     }
     display_close(ds);
@@ -5710,7 +5710,7 @@ static void parse_arguments(ExecCmdState *es)
             goto fail;
         type = cas.arg_type & CMD_ARG_TYPE_MASK;
         argp = &es->args[es->nb_args];
-        es->args_type[es->nb_args] = type;
+        es->args_type[es->nb_args] = (unsigned char)type;
         get_arg = 0;
         switch (type) {
         case CMD_ARG_INTVAL:
@@ -5864,9 +5864,9 @@ static void arg_edit_cb(void *opaque, char *str, CompletionDef *completion)
     switch (es->args_type[index]) {
     case CMD_ARG_INT:
         if (completion && completion->convert_entry) {
-            val = completion->convert_entry(es->s, str, &p);
+            val = (int)completion->convert_entry(es->s, str, &p);
         } else {
-            val = strtol_c(str, &p, 0);
+            val = (int)strtol_c(str, &p, 0);
         }
         if (*p != '\0') {
             put_error(es->s, "Invalid number: %s", str);
@@ -5991,7 +5991,7 @@ void qe_display(QEmacsState *qs)
                           qs->status_shadow, QE_STYLE_STATUS);
         }
         if (*qs->diag_shadow) {
-            int w = strlen(qs->diag_shadow) + 1;
+            int w = (int)strlen(qs->diag_shadow) + 1;
             w *= get_glyph_width(qs->screen, NULL, QE_STYLE_STATUS, '0');
             print_at_byte(qs->screen, x + width - w, y, w, height,
                           qs->diag_shadow, QE_STYLE_STATUS);
@@ -6368,7 +6368,7 @@ void do_define_kbd_macro(EditState *s, const char *name, const char *keys,
     int size, name_len;
     char *buf;
 
-    size = 2 + strlen(keys) + 3;
+    size = 2 + (int)strlen(keys) + 3;
     buf = qe_malloc_array(char, size);
     if (buf == NULL)
         return;
@@ -6378,7 +6378,7 @@ void do_define_kbd_macro(EditState *s, const char *name, const char *keys,
     /* CG: should parse macro keys to an array and pass index
      * to do_execute_macro.
      */
-    snprintf(buf, size, "@{%s}%c", keys, 0);
+    snprintf(buf, (size_t)size, "@{%s}%c", keys, 0);
 
     d = qe_find_cmd(s->qs, name);
     if (d && d->action.ESs == do_execute_macro_keys) {
@@ -6467,7 +6467,7 @@ static void qe_macro_add_key(QEmacsState *qs, int key)
             return;
         qs->macro_keys_size = new_size;
     }
-    qs->macro_keys[qs->nb_macro_keys++] = key;
+    qs->macro_keys[qs->nb_macro_keys++] = (unsigned short)key;
 }
 
 /*---------------- multi-cursor handling ----------------*/
@@ -6717,7 +6717,7 @@ static void qe_key_process(QEmacsState *qs, int key)
         return;
     }
 
-    c->keys[c->nb_keys++] = key;
+    c->keys[c->nb_keys++] = (unsigned int)key;
     s = qs->active_window;
     if (s == NULL) {
         s = qs->active_window = qs->first_window;
@@ -6735,7 +6735,7 @@ static void qe_key_process(QEmacsState *qs, int key)
     if (c->is_escape) {
         compose_keys(c->keys, &c->nb_keys);
         c->is_escape = 0;
-        key = c->keys[c->nb_keys - 1];
+        key = (int)c->keys[c->nb_keys - 1];
     }
 
     /* see if one command is found */
@@ -6787,7 +6787,7 @@ static void qe_key_process(QEmacsState *qs, int key)
             buf_put_keys(out, c->keys, c->nb_keys);
             if (key_redirect != KEY_NONE) {
                 buf_puts(out, " redirected to ");
-                buf_put_key(out, key_redirect);
+                buf_put_key(out, (int)key_redirect);
             }
             if (c->describe_key > 1) {
                 int save_offset = s->b->offset;
@@ -6876,7 +6876,7 @@ static void qe_key_process(QEmacsState *qs, int key)
  next:
     /* display prefix key pressed */
     if (key >= 0) {
-        len = strlen(c->buf);
+        len = (int)strlen(c->buf);
         if (len > 0 && c->buf[len-1] == '-')
             c->buf[len-1] = ' ';
         /* Should print argument if any in a more readable way */
@@ -7045,7 +7045,7 @@ void put_status(EditState *s, const char *fmt, ...)
         if (diag) {
             if (force || !strequal(p, qs->diag_shadow)) {
                 /* right align display and overwrite last diag message */
-                int w = strlen(qs->diag_shadow);
+                int w = (int)strlen(qs->diag_shadow);
                 w = snprintf(qs->diag_shadow, sizeof(qs->diag_shadow),
                              "%*s", w, p) + 1;
                 w *= get_glyph_width(qs->screen, NULL, QE_STYLE_STATUS, '0');
@@ -7364,7 +7364,7 @@ void file_complete(CompleteState *cp, CompleteFunc enumerate)
 
         base = get_basename(filename);
         /* ignore known backup files (hardcoded test for *~) */
-        len = strlen(base);
+        len = (int)strlen(base);
         if (!len || base[len - 1] == '~')
             continue;
         /* ignore known binary file extensions */
@@ -7461,7 +7461,7 @@ static int default_completion_window_get_entry(EditState *s, char *dest, int siz
     int len = eb_fgets(s->b, dest, size, offset, &offset);
     char *p = strchr(dest, '\t');
     if (p != NULL)
-        len = p - dest;
+        len = (int)(p - dest);
     dest[len] = '\0';   /* strip the TAB or trailing newline if any */
     return len;
 }
@@ -7546,8 +7546,8 @@ static void complete_test(CompleteState *cp, const char *str, int mode) {
             return;
         break;
     case CT_TEST:
-        if (memcmp(str, cp->current, cp->len)) {
-            if (!qe_memicmp(str, cp->current, cp->len))
+        if (memcmp(str, cp->current, (size_t)cp->len)) {
+            if (!qe_memicmp(str, cp->current, (size_t)cp->len))
                 fuzzy = 1;
             else
             if (cp->fuzzy && strmem(str, cp->current, cp->len))
@@ -7605,7 +7605,7 @@ static int match_strings(const char *s1, const char *s2, int len) {
     int pos, i;
 
     for (i = pos = 0; i < len; i++) {
-        u8 c = s1[i];
+        u8 c = (u8)s1[i];
         if (!utf8_is_trailing_byte(c))
             pos = i;
         if (c != s2[i])
@@ -7690,15 +7690,15 @@ void do_minibuffer_complete(EditState *s, int type, int key, int argval) {
 
     if (count > 0) {
         /* find the longest common prefix */
-        match_len = strlen(outputs[0]->str);
+        match_len = (int)strlen(outputs[0]->str);
         for (i = 1; i < count; i++) {
             match_len = match_strings(outputs[0]->str, outputs[i]->str,
                                       match_len);
         }
         /* strip extra data */
-        p = memchr(outputs[0]->str, '\t', match_len);
+        p = memchr(outputs[0]->str, '\t', (size_t)match_len);
         if (p)
-            match_len = p - outputs[0]->str;
+            match_len = (int)(p - outputs[0]->str);
     }
     if (match_len > cs.len) {
         /* add the possible chars */
@@ -7884,7 +7884,7 @@ static void minibuffer_set_str(EditState *s, int start, int end, const char *str
 {
     /* Replace the completion trigger zone */
     /* XXX: should insert UTF-8? */
-    start += eb_replace(s->b, start, end - start, str, strlen(str));
+    start += eb_replace(s->b, start, end - start, str, (int)strlen(str));
     s->offset = start;
 }
 
@@ -8115,7 +8115,7 @@ void minibuffer_edit(EditState *e, const char *input, const char *prompt,
     /* add default input */
     if (input) {
         /* Default input should already be encoded as UTF-8 */
-        len = strlen(input);
+        len = (int)strlen(input);
         eb_write(b, 0, (const u8 *)input, len);
         s->offset = len;
     }
@@ -8676,13 +8676,13 @@ void canonicalize_absolute_buffer_path(EditBuffer *b, int offset, char *buf, int
                 size_t ulen = strcspn(username, "/");
                 char uname[128];
                 struct passwd *pw;
-                pstrncpy(uname, sizeof(uname), username, ulen);
+                pstrncpy(uname, sizeof(uname), username, (int)ulen);
                 pw = getpwnam(uname);
                 if (pw) {
                     pstrcpy(path, sizeof(path), pw->pw_dir);
                 } else {
                     pstrcpy(path, sizeof(path), "/home/");
-                    pstrncat(path, sizeof(path), username, ulen);
+                    pstrncat(path, sizeof(path), username, (int)ulen);
                 }
                 pstrcat(path, sizeof(path), username + ulen);
                 path1 = path;
@@ -8781,14 +8781,14 @@ static int probe_mode(EditState *s, EditBuffer *b,
             if (ch == ESCAPE_CHAR) {
                 probe_data.charset_state.p = rawbuf + offset - 1;
                 ch = probe_data.charset_state.decode_func(&probe_data.charset_state);
-                offset = probe_data.charset_state.p - rawbuf;
+                offset = (int)(probe_data.charset_state.p - rawbuf);
             }
             bufp += utf8_encode((char *)bufp, ch);
             if (bufp > buf + sizeof(buf) - MAX_CHAR_BYTES - 1)
                 break;
         }
         probe_data.buf = buf;
-        probe_data.buf_size = bufp - buf;
+        probe_data.buf_size = (int)(bufp - buf);
         *bufp = '\0';
     }
 
@@ -8803,8 +8803,8 @@ static int probe_mode(EditState *s, EditBuffer *b,
 
     charset_decode_close(&probe_data.charset_state);
 
-    p = memchr(probe_data.buf, '\n', probe_data.buf_size);
-    probe_data.line_len = p ? p - probe_data.buf : probe_data.buf_size;
+    p = memchr(probe_data.buf, '\n', (size_t)probe_data.buf_size);
+    probe_data.line_len = p ? (int)(p - probe_data.buf) : probe_data.buf_size;
 
     for (m = qs->first_mode; m != NULL; m = m->next) {
         if (m->mode_probe) {
@@ -9040,7 +9040,7 @@ int qe_load_file(EditState *s, const char *filename1, int lflags, int bflags)
         do_load_qerc(s, s->b->filename);
         return 2;
     } else {
-        b->st_mode = st_mode = st.st_mode;
+        b->st_mode = st_mode = (int)st.st_mode;
         buf_size = 0;
         f = NULL;
 
@@ -9048,7 +9048,7 @@ int qe_load_file(EditState *s, const char *filename1, int lflags, int bflags)
             f = fopen(filename, "r");
             if (!f)
                 goto fail;
-            buf_size = fread(buf, 1, sizeof(buf) - 1, f);
+            buf_size = (int)fread(buf, 1, sizeof(buf) - 1, f);
             if (buf_size <= 0 && ferror(f)) {
                 fclose(f);
                 f = NULL;
@@ -9871,7 +9871,7 @@ void do_create_window(EditState *s, const char *filename, const char *layout)
     }
 
     for (n = 0; *p; n++) {
-        while (qe_isblank(*p))
+        while (qe_isblank((unsigned char)*p))
             p++;
         for (i = 0; i < countof(names); i++) {
             if (strstart(p, names[i], &p)) {
@@ -9886,8 +9886,8 @@ void do_create_window(EditState *s, const char *filename, const char *layout)
         if (n >= countof(args))
             break;
 
-        args[n] = strtol_c(p, &p, 0);
-        while (qe_isblank(*p))
+        args[n] = (int)strtol_c(p, &p, 0);
+        while (qe_isblank((unsigned char)*p))
             p++;
         if (*p == ',')
             p++;
@@ -10746,7 +10746,7 @@ void do_load_qerc(EditState *e, const char *filename)
         if (!p)
             break;
         p += 1;
-        pstrcpy(p, buf + sizeof(buf) - p, ".qerc.lua");
+        pstrcpy(p, (int)(buf + sizeof(buf) - p), ".qerc.lua");
         qs->active_window = e;
         parse_config_file(e, buf);
     }
@@ -10869,8 +10869,8 @@ static int qe_parse_command_line(QEmacsState *qs, int argc, char **argv)
             }
             r++;
         }
-        opt1.len = r - opt1.s;
-        opt2.len = r - opt2.s;
+        opt1.len = (int)(r - opt1.s);
+        opt2.len = (int)(r - opt2.s);
 
         for (p = first_cmd_options; p != NULL; p = p->u.next) {
             while (p->desc != NULL) {
@@ -10892,7 +10892,7 @@ static int qe_parse_command_line(QEmacsState *qs, int argc, char **argv)
                         *p->u.int_ptr = optarg_ ? qe_strtobool(optarg_, 1) : TRUE;
                         break;
                     case CMD_LINE_TYPE_INT:
-                        *p->u.int_ptr = optarg_ ? strtol(optarg_, NULL, 0) : *p->u.int_ptr + 1;
+                        *p->u.int_ptr = optarg_ ? (int)strtol(optarg_, NULL, 0) : *p->u.int_ptr + 1;
                         break;
                     case CMD_LINE_TYPE_STRING:
                         *p->u.string_ptr = optarg_;
@@ -11899,9 +11899,9 @@ static int qe_init(void *opaque)
                 continue;
             }
             /* Handle +linenumber[,column] before file */
-            line_num = strtol(arg + 1, &p, 10);
+            line_num = (int)strtol(arg + 1, &p, 10);
             if (*p == ',' || *p == ':') {
-                col_num = strtol(p + 1, NULL, 10);
+                col_num = (int)strtol(p + 1, NULL, 10);
                 col_num -= (col_num > 0);  // user column numbers are 1-based
             }
             arg = argv[i++];

--- a/qe.h
+++ b/qe.h
@@ -1368,17 +1368,17 @@ static inline int display_char(DisplayState *s, int offset1, int offset2,
     return display_char_bidir(s, offset1, offset2, 0, ch);
 }
 
-#define SET_STYLE(sbuf,a,b,style)  cp_set_style((sbuf) + (a), (sbuf) + (b), style)
+#define SET_STYLE(sbuf,a,b,style)  cp_set_style((sbuf) + (a), (sbuf) + (b), (QETermStyle)(style))
 
-static inline void cp_set_style(QETermStyle *p, QETermStyle *to, int style) {
+static inline void cp_set_style(QETermStyle *p, QETermStyle *to, QETermStyle style) {
     while (p < to)
-        *p++ = (QETermStyle)style;
+        *p++ = style;
 }
 
-#define SET_STYLE1(sbuf,a,style)  cp_set_style1((sbuf) + (a), style)
+#define SET_STYLE1(sbuf,a,style)  cp_set_style1((sbuf) + (a), (QETermStyle)(style))
 
-static inline void cp_set_style1(QETermStyle *p, int style) {
-    *p = (QETermStyle)style;
+static inline void cp_set_style1(QETermStyle *p, QETermStyle style) {
+    *p = style;
 }
 
 /* input.c */

--- a/qe.h
+++ b/qe.h
@@ -539,7 +539,7 @@ static inline int eb_prev(EditBuffer *b, int offset) {
     return offset;
 }
 static inline int eb_peekc(EditBuffer *b, int offset) {
-    return eb_nextc(b, offset, &offset);
+    return (int)eb_nextc(b, offset, &offset);
 }
 
 //int eb_clip_offset(EditBuffer *b, int offset);
@@ -1372,13 +1372,13 @@ static inline int display_char(DisplayState *s, int offset1, int offset2,
 
 static inline void cp_set_style(QETermStyle *p, QETermStyle *to, int style) {
     while (p < to)
-        *p++ = style;
+        *p++ = (QETermStyle)style;
 }
 
 #define SET_STYLE1(sbuf,a,style)  cp_set_style1((sbuf) + (a), style)
 
 static inline void cp_set_style1(QETermStyle *p, int style) {
-    *p = style;
+    *p = (QETermStyle)style;
 }
 
 /* input.c */

--- a/search.c
+++ b/search.c
@@ -161,7 +161,7 @@ static int eb_search(EditBuffer *b, int dir, int flags,
             pos = 0;
             for (offset2 = offset; offset2 < total_size;) {
                 /* CG: Should bufferize a bit ? */
-                c = eb_read_one_byte(b, offset2++);
+                c = (char32_t)eb_read_one_byte(b, offset2++);
                 c2 = buf[pos++];
                 if (c != c2)
                     break;
@@ -199,7 +199,7 @@ static int eb_search(EditBuffer *b, int dir, int flags,
         if (source_len >= countof(source))
             return -1;
         regexp_bytes = lre_compile(&regexp_len, error_message, sizeof(error_message),
-                                   source, source_len, re_flags, NULL);
+                                   source, (size_t)source_len, re_flags, NULL);
         if (regexp_bytes == NULL) {
             //put_error(b->qs->active_window, "Regexp compile error: %s", error_message);
             return -1;
@@ -241,8 +241,8 @@ static int eb_search(EditBuffer *b, int dir, int flags,
                 break;
             }
             if (found > 0) {
-                int start = capture[0] - (uint8_t *)(void *)b;
-                int end = capture[1] - (uint8_t *)(void *)b;
+                int start = (int)(capture[0] - (uint8_t *)(void *)b);
+                int end = (int)(capture[1] - (uint8_t *)(void *)b);
                 if ((dir >= 0 || end <= end_offset)
                 &&  (!(flags & SEARCH_FLAG_WORD) ||
                      (qe_isword(eb_prevc(b, start, &offset3)) &&
@@ -422,7 +422,7 @@ static void isearch_run(ISearchState *is) {
     len = 0;
     dir = is->start_dir;
     search_offset = is->start_offset;
-    max_nibble = hex_nibble = hc = 0;
+    max_nibble = hex_nibble = 0; hc = 0;
 
     if (flags & SEARCH_FLAG_UNIHEX)
         max_nibble = 6;
@@ -449,15 +449,15 @@ static void isearch_run(ISearchState *is) {
             if (max_nibble) {
                 h = qe_digit_value(c);
                 if (h < 16) {
-                    hc = (hc << 4) | h;
+                    hc = (hc << 4) | (char32_t)h;
                     if (++hex_nibble == max_nibble) {
                         is->search_u32[len++] = hc;
-                        hex_nibble = hc = 0;
+                        hex_nibble = 0; hc = 0;
                     }
                 } else {
                     if (c == ' ' && hex_nibble) {
                         is->search_u32[len++] = hc;
-                        hex_nibble = hc = 0;
+                        hex_nibble = 0; hc = 0;
                     }
                 }
             } else {
@@ -467,7 +467,7 @@ static void isearch_run(ISearchState *is) {
     }
     if (hex_nibble >= 2 && len < countof(is->search_u32)) {
         is->search_u32[len++] = hc;
-        hex_nibble = hc = 0;
+        hex_nibble = 0; hc = 0;
     }
 
     is->search_u32_len = len;
@@ -677,13 +677,13 @@ static void isearch_addpos(EditState *s, int dir) {
     } else
     if (is->pos < countof(is->search_u32_steps)) {
         /* add the match position, if any */
-        unsigned long v = (is->dir >= 0) ? FOUND_TAG : FOUND_TAG | FOUND_REV;
+        unsigned int v = (is->dir >= 0) ? FOUND_TAG : FOUND_TAG | FOUND_REV;
         if (is->found_offset < 0 && is->search_u32_len > 0) {
             is->search_flags |= SEARCH_FLAG_WRAPPED;
             if (is->dir < 0)
-                v |= is->s->b->total_size;
+                v |= (unsigned int)is->s->b->total_size;
         } else {
-            v |= is->s->offset;
+            v |= (unsigned int)is->s->offset;
         }
         is->search_u32_steps[is->pos++] = v;
     }
@@ -693,7 +693,7 @@ static void isearch_printing_char(EditState *s, int key) {
     ISearchState *is = s->isearch_state;
     if (is) {
         if (is->pos < countof(is->search_u32_steps))
-            is->search_u32_steps[is->pos++] = key;
+            is->search_u32_steps[is->pos++] = (unsigned int)key;
     }
 }
 
@@ -831,7 +831,7 @@ static void isearch_exit(EditState *s, int key) {
 static void isearch_key(void *opaque, int key) {
     ISearchState *is = opaque;
     QEmacsState *qs = is->s->qs;
-    unsigned int keys[1] = { key };
+    unsigned int keys[1] = { (unsigned int)key };
 
     if (is->quoting) {
         is->quoting = 0;
@@ -925,7 +925,7 @@ static int search_to_u32(char32_t *buf, int size,
             c = *s++;
             if (c == '\0') {
                 if (hex_nibble >= 2) {
-                    buf[len++] = hc;
+                    buf[len++] = (char32_t)hc;
                     hex_nibble = hc = 0;
                 }
                 break;
@@ -934,12 +934,12 @@ static int search_to_u32(char32_t *buf, int size,
             if (h < 16) {
                 hc = (hc << 4) | h;
                 if (++hex_nibble == max_nibble) {
-                    buf[len++] = hc;
+                    buf[len++] = (char32_t)hc;
                     hex_nibble = hc = 0;
                 }
             } else {
                 if (c == ' ' && hex_nibble) {
-                    buf[len++] = hc;
+                    buf[len++] = (char32_t)hc;
                     hex_nibble = hc = 0;
                 }
             }

--- a/session.c
+++ b/session.c
@@ -174,7 +174,7 @@ static int alternate_buffer;
  */
 static ssize_t write_all_timeout(int fd, const char *buf, size_t len,
                                  int timeout_ms) {
-    ssize_t ret = len;
+    ssize_t ret = (ssize_t)len;
     while (len > 0) {
         ssize_t res = write(fd, buf, len);
         if (res < 0) {
@@ -196,7 +196,7 @@ static ssize_t write_all_timeout(int fd, const char *buf, size_t len,
         if (res == 0)
             return ret - (ssize_t)len;
         buf += res;
-        len -= res;
+        len -= (size_t)res;
     }
     return ret;
 }
@@ -206,7 +206,7 @@ static ssize_t write_all(int fd, const char *buf, size_t len) {
 }
 
 static ssize_t read_all(int fd, char *buf, size_t len) {
-    ssize_t ret = len;
+    ssize_t ret = (ssize_t)len;
     while (len > 0) {
         ssize_t res = read(fd, buf, len);
         if (res < 0) {
@@ -219,7 +219,7 @@ static ssize_t read_all(int fd, char *buf, size_t len) {
         if (res == 0)
             return ret - (ssize_t)len;
         buf += res;
-        len -= res;
+        len -= (size_t)res;
     }
     return ret;
 }
@@ -346,7 +346,7 @@ static int server_create_socket(const char *name) {
     if (fd == -1)
         return -1;
 
-    socklen_t socklen = offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path) + 1;
+    socklen_t socklen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path) + 1);
     mode_t mask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
     int r = bind(fd, (struct sockaddr *)&addr, socklen);
     if (r == -1 && errno == EADDRINUSE) {
@@ -389,7 +389,7 @@ static int session_connect(const char *name) {
     if (fd == -1)
         return -1;
 
-    socklen_t socklen = offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path) + 1;
+    socklen_t socklen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + strlen(addr.sun_path) + 1);
     if (connect(fd, (struct sockaddr *)&addr, socklen) == -1) {
         /* Clean up stale socket */
         if (errno == ECONNREFUSED && stat(addr.sun_path, &sb) == 0 && S_ISSOCK(sb.st_mode))
@@ -482,7 +482,7 @@ static Client *server_accept_client(void) {
     memset(&pkt, 0, sizeof(pkt));
     pkt.type = MSG_PID;
     pkt.len = sizeof(pkt.u.l);
-    pkt.u.l = getpid();
+    pkt.u.l = (uint64_t)getpid();
     if (send_packet_nonblock(c->socket, &pkt) < 0) {
         /* Client already dead or buffer full — drop it */
         server.clients = c->next;
@@ -543,21 +543,21 @@ static void server_mainloop(void) {
             ssize_t len = read(server.pty, server_pkt.u.msg, sizeof(server_pkt.u.msg));
             if (len > 0) {
                 /* Check for OSC detach escape sequence from qemacs */
-                char *osc = memmem(server_pkt.u.msg, len,
+                char *osc = memmem(server_pkt.u.msg, (size_t)len,
                                    QE_OSC_DETACH, QE_OSC_DETACH_LEN);
                 if (osc) {
                     /* Remove the OSC sequence from output */
-                    size_t before = osc - server_pkt.u.msg;
-                    size_t after = len - before - QE_OSC_DETACH_LEN;
+                    size_t before = (size_t)(osc - server_pkt.u.msg);
+                    size_t after = (size_t)len - before - QE_OSC_DETACH_LEN;
                     if (after > 0)
                         memmove(osc, osc + QE_OSC_DETACH_LEN, after);
-                    len = before + after;
+                    len = (ssize_t)(before + after);
                     /* Mark all clients for disconnection */
                     for (Client *dc = server.clients; dc; dc = dc->next)
                         dc->state = STATE_DISCONNECTED;
                 }
                 if (len > 0) {
-                    server_pkt.len = len;
+                    server_pkt.len = (uint32_t)len;
                     pty_data = 1;
                 }
             } else if (len == 0) {
@@ -584,7 +584,7 @@ static void server_mainloop(void) {
                                           client_pkt.len, 1000);
                         break;
                     case MSG_ATTACH:
-                        c->flags = client_pkt.u.i;
+                        c->flags = (int)client_pkt.u.i;
                         c->state = STATE_ATTACHED;
                         break;
                     case MSG_RESIZE:
@@ -641,7 +641,7 @@ static void server_mainloop(void) {
                 Packet epkt;
                 memset(&epkt, 0, sizeof(epkt));
                 epkt.type = MSG_EXIT;
-                epkt.u.i = server.exit_status;
+                epkt.u.i = (uint32_t)server.exit_status;
                 epkt.len = sizeof(epkt.u.i);
                 if (send_packet_nonblock(c->socket, &epkt) < 0)
                     c->state = STATE_DISCONNECTED;
@@ -746,7 +746,7 @@ static int client_mainloop(void) {
     /* Send attach packet (bounded — server should be ready) */
     memset(&pkt, 0, sizeof(pkt));
     pkt.type = MSG_ATTACH;
-    pkt.u.i = client.flags;
+    pkt.u.i = (uint32_t)client.flags;
     pkt.len = sizeof(pkt.u.i);
     if (send_packet_timeout(client.server_socket, &pkt, 5000) < 0)
         return -2;
@@ -795,7 +795,7 @@ static int client_mainloop(void) {
                 case MSG_EXIT:
                     send_packet_nonblock(client.server_socket, &rpkt);
                     close(client.server_socket);
-                    return rpkt.u.i;
+                    return (int)rpkt.u.i;
                 default:
                     break;
                 }
@@ -812,7 +812,7 @@ static int client_mainloop(void) {
             if (len == -1 && errno != EAGAIN && errno != EINTR)
                 break;
             if (len > 0) {
-                ipkt.len = len;
+                ipkt.len = (uint32_t)len;
                 if (ipkt.u.msg[0] == key_detach) {
                     Packet dpkt;
                     memset(&dpkt, 0, sizeof(dpkt));
@@ -971,7 +971,7 @@ static int create_session(const char *name, int argc, char **argv) {
         {
             ssize_t len = read_all(client_pipe[0], errormsg, sizeof(errormsg));
             if (len > 0) {
-                write_all(STDERR_FILENO, errormsg, len);
+                write_all(STDERR_FILENO, errormsg, (size_t)len);
                 unlink(server.socket_path);
                 close(client_pipe[0]);
                 return -1;

--- a/test_display.c
+++ b/test_display.c
@@ -127,7 +127,7 @@ static int test_parse_sgr_mouse(const unsigned char *buf, int len, int start,
         pos++;
     }
     if (pos >= len) return 0;
-    terminator = buf[pos];
+    terminator = (char)buf[pos];
     if (terminator != 'M' && terminator != 'm') return 0;
     pos++;
 
@@ -164,7 +164,7 @@ static void test_read_handler(void *opaque)
     unsigned char buf[64];
     int n, i;
 
-    n = read(ts->input_fd, buf, sizeof(buf));
+    n = (int)read(ts->input_fd, buf, sizeof(buf));
     if (n <= 0) {
         /* EOF or error on input — request exit */
         url_exit();
@@ -325,19 +325,19 @@ static void test_dump_screen(QEditScreen *s)
             if (ch < 32 || ch == 127) ch = '.';
             /* Output UTF-8 */
             if (ch < 0x80) {
-                fputc(ch, f);
+                fputc((int)ch, f);
             } else if (ch < 0x800) {
-                fputc(0xC0 | (ch >> 6), f);
-                fputc(0x80 | (ch & 0x3F), f);
+                fputc((int)(0xC0 | (ch >> 6)), f);
+                fputc((int)(0x80 | (ch & 0x3F)), f);
             } else if (ch < 0x10000) {
-                fputc(0xE0 | (ch >> 12), f);
-                fputc(0x80 | ((ch >> 6) & 0x3F), f);
-                fputc(0x80 | (ch & 0x3F), f);
+                fputc((int)(0xE0 | (ch >> 12)), f);
+                fputc((int)(0x80 | ((ch >> 6) & 0x3F)), f);
+                fputc((int)(0x80 | (ch & 0x3F)), f);
             } else {
-                fputc(0xF0 | (ch >> 18), f);
-                fputc(0x80 | ((ch >> 12) & 0x3F), f);
-                fputc(0x80 | ((ch >> 6) & 0x3F), f);
-                fputc(0x80 | (ch & 0x3F), f);
+                fputc((int)(0xF0 | (ch >> 18)), f);
+                fputc((int)(0x80 | ((ch >> 12) & 0x3F)), f);
+                fputc((int)(0x80 | ((ch >> 6) & 0x3F)), f);
+                fputc((int)(0x80 | (ch & 0x3F)), f);
             }
         }
         fputc('|', f);
@@ -386,14 +386,14 @@ static void test_dpy_fill_rectangle(QEditScreen *s,
     if (y2 > s->clip_y2) y2 = s->clip_y2;
 
     /* Map QEColor to a simple color index (0-15 range) */
-    int bgcolor = qe_map_color(color, xterm_colors, 16, NULL);
+    int bgcolor = (int)qe_map_color(color, xterm_colors, 16, NULL);
 
     for (y = y1; y < y2; y++) {
         for (x = x1; x < x2; x++) {
             TestCell *cell = &ts->screen[y * s->width + x];
             cell->ch = ' ';
             cell->fg = 7;
-            cell->bg = bgcolor;
+            cell->bg = (uint16_t)bgcolor;
             cell->attrs = 0;
         }
     }
@@ -460,7 +460,7 @@ static void test_dpy_draw_text(QEditScreen *s, QEFont *font,
                                QEColor color)
 {
     TestDisplayState *ts = s->priv_data;
-    int fgcolor;
+    unsigned int fgcolor;
     uint16_t attrs = 0;
 
     if (y < s->clip_y1 || y >= s->clip_y2 || x >= s->clip_x2)
@@ -483,7 +483,7 @@ static void test_dpy_draw_text(QEditScreen *s, QEFont *font,
 
         TestCell *cell = &ts->screen[y * s->width + x];
         cell->ch = ch;
-        cell->fg = fgcolor;
+        cell->fg = (uint16_t)fgcolor;
         /* Preserve existing bg color (set by fill_rectangle) */
         cell->attrs = attrs;
         x += w;
@@ -492,7 +492,7 @@ static void test_dpy_draw_text(QEditScreen *s, QEFont *font,
         if (w == 2 && x < s->clip_x2) {
             cell = &ts->screen[y * s->width + x];
             cell->ch = ' ';
-            cell->fg = fgcolor;
+            cell->fg = (uint16_t)fgcolor;
             cell->attrs = attrs;
             /* x already incremented by w */
         }

--- a/tty.c
+++ b/tty.c
@@ -116,7 +116,7 @@ typedef struct TTYState {
     u8 last_ch, this_ch;
     int has_meta;
     int nb_params;
-#define CSI_PARAM_OMITTED  0x80000000
+#define CSI_PARAM_OMITTED  (int)0x80000000U
     int params[3];
     int leader;
     int interm;
@@ -288,7 +288,7 @@ static int tty_dpy_init(QEditScreen *s, QEmacsState *qs,
     tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP |
                      INLCR | IGNCR | ICRNL | IXON);
     /* output modes - disable post processing */
-    tty.c_oflag &= ~(OPOST);
+    tty.c_oflag &= (tcflag_t)~(OPOST);
     /* local modes - echoing off, canonical off, no extended functions,
      * no signal chars (^Z,^C) */
     tty.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
@@ -424,7 +424,7 @@ static void tty_dpy_invalidate(QEditScreen *s)
         s->height = 25;
 
     count = s->width * s->height;
-    size = count * sizeof(TTYChar);
+    size = (int)((size_t)count * sizeof(TTYChar));
     /* screen buffer + shadow buffer + extra slot for loop guard */
     // XXX: test for failure
     qe_realloc_array(&ts->screen, count * 2 + 1);
@@ -432,14 +432,14 @@ static void tty_dpy_invalidate(QEditScreen *s)
     ts->screen_size = count;
 
     /* Erase shadow buffer to impossible value */
-    memset(ts->screen + count, 0xFF, size + sizeof(TTYChar));
+    memset(ts->screen + count, 0xFF, (size_t)size + sizeof(TTYChar));
     /* Fill screen buffer with black spaces */
     tc = TTY_CHAR_DEFAULT;
     for (i = 0; i < count; i++) {
         ts->screen[i] = tc;
     }
     /* All rows need refresh */
-    memset(ts->line_updated, 1, s->height);
+    memset(ts->line_updated, 1, (size_t)s->height);
 
     s->clip_x1 = 0;
     s->clip_y1 = 0;
@@ -493,11 +493,11 @@ static int tty_get_clipboard(QEditScreen *s, int ch)
     if (p3 >= p4)
         return -1;
 
-    contents = qe_decode64(p3, p4 - p3, &size);
+    contents = qe_decode64(p3, (size_t)(p4 - p3), &size);
     if (!contents)
         return -1;
     if (qs->trace_buffer)
-        qe_trace_bytes(qs, contents, size, EB_TRACE_CLIPBOARD);
+        qe_trace_bytes(qs, contents, (int)size, EB_TRACE_CLIPBOARD);
     if (size == ts->clipboard_size && !memcmp(ts->clipboard, contents, size)) {
         qe_free(&contents);
         return 0;
@@ -508,7 +508,7 @@ static int tty_get_clipboard(QEditScreen *s, int ch)
         /* copy terminal selection a new yank buffer */
         b = qe_new_yank_buffer(qs, NULL);
         eb_set_charset(b, &charset_utf8, EOL_UNIX);
-        eb_write(b, 0, contents, size);
+        eb_write(b, 0, contents, (int)size);
         return 1;
     }
 }
@@ -537,23 +537,23 @@ static int tty_set_clipboard(QEditScreen *s)
     QEmacsState *qs = s->qs;
     TTYState *ts = s->priv_data;
     EditBuffer *b = qs->yank_buffers[qs->yank_current];
-    size_t size;
+    int size;
     char *contents;
 
     if (!b)
         return 0;
     size = eb_get_region_content_size(b, 0, b->total_size);
-    contents = qe_malloc_bytes(size + 1);
+    contents = qe_malloc_bytes((size_t)size + 1);
     if (!contents)
         return -1;
     eb_get_region_contents(b, 0, b->total_size, contents, size + 1, FALSE);
-    if (size == ts->clipboard_size && !memcmp(ts->clipboard, contents, size)) {
+    if ((size_t)size == ts->clipboard_size && !memcmp(ts->clipboard, contents, (size_t)size)) {
         qe_free(&contents);
         return 0;
     }
     if (tty_clipboard == 1) {
         size_t encoded_size;
-        char *encoded_contents = qe_encode64(contents, size, &encoded_size);
+        char *encoded_contents = qe_encode64(contents, (size_t)size, &encoded_size);
         if (!encoded_contents) {
             qe_free(&contents);
             return -1;
@@ -565,7 +565,7 @@ static int tty_set_clipboard(QEditScreen *s)
     }
     qe_free(&ts->clipboard);
     ts->clipboard = contents;
-    ts->clipboard_size = size;
+    ts->clipboard_size = (size_t)size;
     return 0;
 }
 
@@ -641,23 +641,23 @@ static void tty_read_handler(void *opaque)
     shift = 0;
     ch = buf[0];
     ts->last_ch = ts->this_ch;
-    ts->this_ch = ch;
+    ts->this_ch = (u8)ch;
     /* keep TTY bytes for error messages */
     if (qs->input_len >= qs->input_size) {
         qs->input_size += qs->input_size / 2 + 64;
         if (qs->input_buf == qs->input_buf_def) {
-            qs->input_buf = qe_malloc_bytes(qs->input_size);
-            memcpy(qs->input_buf, qs->input_buf_def, qs->input_len);
+            qs->input_buf = qe_malloc_bytes((size_t)qs->input_size);
+            memcpy(qs->input_buf, qs->input_buf_def, (size_t)qs->input_len);
         } else {
-            qe_realloc_bytes(&qs->input_buf, qs->input_size);
+            qe_realloc_bytes(&qs->input_buf, (size_t)qs->input_size);
         }
     }
-    qs->input_buf[qs->input_len++] = ch;
+    qs->input_buf[qs->input_len++] = (u8)ch;
 
     switch (ts->input_state) {
     case IS_NORM:
         qs->input_len = 1;
-        qs->input_buf[0] = ch;
+        qs->input_buf[0] = (u8)ch;
         /* charset handling */
         if (s->charset == &charset_utf8) {
             if (ts->utf8_index && (ch ^ 0x80) > 0x3f) {
@@ -666,7 +666,7 @@ static void tty_read_handler(void *opaque)
                 /* XXX: maybe should consume prefix byte as binary */
                 ts->utf8_index = 0;
             }
-            ts->buf[ts->utf8_index] = ch;
+            ts->buf[ts->utf8_index] = (unsigned char)ch;
             len = utf8_length[ts->buf[0]];
             if (len > 1) {
                 const char *p = cs8(ts->buf);
@@ -674,7 +674,7 @@ static void tty_read_handler(void *opaque)
                     /* valid utf8 sequence underway, wait for next */
                     return;
                 }
-                ch = utf8_decode(&p);
+                ch = (int)utf8_decode(&p);
             }
         }
         if (ch == '\033') {
@@ -688,7 +688,7 @@ static void tty_read_handler(void *opaque)
                     qe_free(&qs->input_buf);
                     qs->input_buf = qs->input_buf_def;
                     qs->input_size = countof(qs->input_buf_def);
-                    qs->input_buf[0] = ch;
+                    qs->input_buf[0] = (u8)ch;
                     qs->input_len = 1;
                 }
                 break;
@@ -705,7 +705,7 @@ static void tty_read_handler(void *opaque)
                 qe_free(&qs->input_buf);
                 qs->input_buf = qs->input_buf_def;
                 qs->input_size = countof(qs->input_buf_def);
-                qs->input_buf[0] = ch;
+                qs->input_buf[0] = (u8)ch;
                 qs->input_len = 1;
             }
             break;
@@ -1030,7 +1030,7 @@ static void tty_read_handler(void *opaque)
             break;
         ts->input_state = IS_NORM;
         ts->has_meta = 0;
-        n1 = strtol(cs8(qs->input_buf) + 2, NULL, 10);
+        n1 = (int)strtol(cs8(qs->input_buf) + 2, NULL, 10);
         if (qs->trace_buffer) {
             char buf1[32];
             snprintf(buf1, sizeof buf1, "tty-osc-%d", n1);
@@ -1152,16 +1152,16 @@ static void tty_dpy_text_metrics(QEditScreen *s, QEFont *font,
 static char32_t comb_cache_add(TTYState *ts, const char32_t *seq, int len) {
     char32_t *ip;
     for (ip = ts->comb_cache; *ip; ip += *ip & 0xFFFF) {
-        if (*ip == len + 1U && !blockcmp(ip + 1, seq, len)) {
-            return TTY_CHAR_COMB + (ip - ts->comb_cache);
+        if (*ip == (char32_t)len + 1U && !blockcmp(ip + 1, seq, len)) {
+            return TTY_CHAR_COMB + (char32_t)(ip - ts->comb_cache);
         }
     }
     for (ip = ts->comb_cache; *ip; ip += *ip & 0xFFFF) {
-        if (*ip >= 0x10001U + len) {
+        if (*ip >= 0x10001U + (char32_t)len) {
             /* found free slot */
-            if (*ip > 0x10001U + len) {
+            if (*ip > 0x10001U + (char32_t)len) {
                 /* split free block */
-                ip[len + 1] = *ip - (len + 1);
+                ip[len + 1] = *ip - (char32_t)(len + 1);
             }
             break;
         }
@@ -1172,9 +1172,9 @@ static char32_t comb_cache_add(TTYState *ts, const char32_t *seq, int len) {
         }
         ip[len + 1] = 0;
     }
-    *ip = len + 1;
+    *ip = (char32_t)(len + 1);
     blockcpy(ip + 1, seq, len);
-    return TTY_CHAR_COMB + (ip - ts->comb_cache);
+    return TTY_CHAR_COMB + (char32_t)(ip - ts->comb_cache);
 }
 
 static void comb_cache_clean(TTYState *ts, const TTYChar *screen, int len) {
@@ -1195,7 +1195,7 @@ static void comb_cache_clean(TTYState *ts, const TTYChar *screen, int len) {
         char32_t ch = TTY_CHAR_GET_CH(screen[i]);
         if (ch >= TTY_CHAR_COMB && ch < TTY_CHAR_COMB + countof(ts->comb_cache) - 1) {
             /* mark the cache entry as used */
-            ip[ch - TTY_CHAR_COMB] &= ~0x10000;
+            ip[ch - TTY_CHAR_COMB] &= (char32_t)~0x10000U;
         }
     }
     /* scan the cache to coalesce free entries */
@@ -1246,7 +1246,8 @@ static void tty_dpy_draw_text(QEditScreen *s, QEFont *font,
 {
     TTYState *ts = s->priv_data;
     TTYChar *ptr;
-    int fgcolor, w, n;
+    unsigned int fgcolor;
+    int w, n;
     char32_t cc;
     const char32_t *str = str0;
 
@@ -1383,7 +1384,8 @@ static void tty_dpy_flush(QEditScreen *s)
 {
     TTYState *ts = s->priv_data;
     TTYChar *ptr, *ptr1, *ptr2, *ptr3, *ptr4, cc, blankcc;
-    int y, shadow, ch, gotopos;
+    int y, shadow, gotopos;
+    char32_t ch;
     uint32_t bgcolor, fgcolor;
     uint64_t attr;
     unsigned int default_bgcolor;
@@ -1497,7 +1499,7 @@ static void tty_dpy_flush(QEditScreen *s)
                     } else
 #if TTY_STYLE_BITS == 32
                     if (bgcolor >= 256) {
-                        QEColor rgb = qe_unmap_color(bgcolor, ts->tty_bg_colors_count);
+                        QEColor rgb = qe_unmap_color((int)bgcolor, ts->tty_bg_colors_count);
                         TTY_FPRINTF(s->STDOUT, "\033[48;2;%u;%u;%um",
                                     (rgb >> 16) & 255, (rgb >> 8) & 255, (rgb >> 0) & 255);
                     } else
@@ -1512,7 +1514,7 @@ static void tty_dpy_flush(QEditScreen *s)
                     fgcolor = TTY_CHAR_GET_FG(cc);
 #if TTY_STYLE_BITS == 32
                     if (fgcolor >= 256) {
-                        QEColor rgb = qe_unmap_color(fgcolor, ts->tty_fg_colors_count);
+                        QEColor rgb = qe_unmap_color((int)fgcolor, ts->tty_fg_colors_count);
                         TTY_FPRINTF(s->STDOUT, "\033[38;2;%u;%u;%um",
                                     (rgb >> 16) & 255, (rgb >> 8) & 255, (rgb >> 0) & 255);
                     } else
@@ -1559,7 +1561,7 @@ static void tty_dpy_flush(QEditScreen *s)
                     TTY_PUTC('.', s->STDOUT);
                 } else
                 if (ch < 127) {
-                    TTY_PUTC(ch, s->STDOUT);
+                    TTY_PUTC((int)ch, s->STDOUT);
                 } else
                 if (ch < 128 + 32) {
                     /* Line drawing: emit Unicode box drawing directly */
@@ -1567,7 +1569,7 @@ static void tty_dpy_flush(QEditScreen *s)
                     char32_t uc = dec_to_unicode[ch - 128];
                     ldq = s->charset->encode_func(s->charset, ldbuf, uc);
                     if (ldq) {
-                        TTY_FWRITE(ldbuf, 1, ldq - ldbuf, s->STDOUT);
+                        TTY_FWRITE(ldbuf, 1, (size_t)(ldq - ldbuf), s->STDOUT);
                     } else {
                         TTY_PUTC('?', s->STDOUT);
                     }
@@ -1576,7 +1578,7 @@ static void tty_dpy_flush(QEditScreen *s)
                 if (ch >= TTY_CHAR_COMB && ch < TTY_CHAR_COMB + COMB_CACHE_SIZE - 1) {
                     u8 buf[10], *q;
                     char32_t *ip = ts->comb_cache + (ch - TTY_CHAR_COMB);
-                    int ncc = *ip++;
+                    int ncc = (int)*ip++;
 
                     /* this is a sanity test: check that we have a valid combination
                        offset: should actually test against some maximum number of
@@ -1586,7 +1588,7 @@ static void tty_dpy_flush(QEditScreen *s)
                         while (ncc-- > 1) {
                             q = s->charset->encode_func(s->charset, buf, *ip++);
                             if (q) {
-                                TTY_FWRITE(buf, 1, q - buf, s->STDOUT);
+                                TTY_FWRITE(buf, 1, (size_t)(q - buf), s->STDOUT);
                                 // XXX: should check s->unicode_version for
                                 //      terminal support of non ASCII codepoint
                                 //      and force GOTOPOS if unsupported
@@ -1624,11 +1626,11 @@ static void tty_dpy_flush(QEditScreen *s)
                         /* force cursor repositioning if glyph may have variants */
                         gotopos |= qe_wcwidth_variant(ch);
                     }
-                    nc = q - buf;
+                    nc = (int)(q - buf);
                     if (nc == 1) {
                         TTY_PUTC(*buf, s->STDOUT);
                     } else {
-                        TTY_FWRITE(buf, 1, nc, s->STDOUT);
+                        TTY_FWRITE(buf, 1, (size_t)nc, s->STDOUT);
                     }
                 }
             }
@@ -1825,8 +1827,8 @@ static int tty_dpy_draw_picture(QEditScreen *s,
             uint32_t *p2 = p1 + (ip->linesize[0] >> 2);
             ts->line_updated[dst_y + y] = 1;
             for (x = 0; x < dst_w; x++) {
-                int bg = p1[x];
-                int fg = p2[x];
+                int bg = (int)p1[x];
+                int fg = (int)p2[x];
                 bg = TTY_RGB_BG(QERGB_RED(bg), QERGB_GREEN(bg), QERGB_BLUE(bg));
                 fg = TTY_RGB_FG(QERGB_RED(fg), QERGB_GREEN(fg), QERGB_BLUE(fg));
                 if (fg == bg)

--- a/unicode_join.c
+++ b/unicode_join.c
@@ -40,7 +40,7 @@ static int uni_get_be16(FILE *f, unsigned short *pv) {
     /* return -1 if end of file */
     int c1, c2;
     if ((c1 = fgetc(f)) != EOF && (c2 = fgetc(f)) != EOF) {
-        *pv = (c1 << 8) | c2;
+        *pv = (unsigned short)((c1 << 8) | c2);
         return 0;
     } else {
         return 1;
@@ -198,7 +198,7 @@ static int unicode_ligature(char32_t *buf_out,
         /* eliminate invisible chars */
         if (l1 >= 0x202a && l1 <= 0x202e) {
             /* LRE, RLE, PDF, RLO, LRO */
-            pos_L_to_V[i] = q - buf_out;
+            pos_L_to_V[i] = (unsigned int)(q - buf_out);
             i++;
             goto found;
         }
@@ -213,8 +213,8 @@ static int unicode_ligature(char32_t *buf_out,
             goto nolig;
         if (l > 0) {
             /* ligature of length 2 found */
-            pos_L_to_V[i] = q - buf_out;
-            pos_L_to_V[i+1] = q - buf_out;
+            pos_L_to_V[i] = (unsigned int)(q - buf_out);
+            pos_L_to_V[i+1] = (unsigned int)(q - buf_out);
             *q++ = (char32_t)l;
             i += 2;
         } else {
@@ -231,7 +231,7 @@ static int unicode_ligature(char32_t *buf_out,
                             goto notfound;
                     }
                     for (j = 0; j < len1; j++)
-                        pos_L_to_V[i + j] = q - buf_out;
+                        pos_L_to_V[i + j] = (unsigned int)(q - buf_out);
                     for (j = 0; j < len2; j++) {
                         *q++ = lig[len1 + j];
                     }
@@ -243,14 +243,14 @@ static int unicode_ligature(char32_t *buf_out,
             }
             /* nothing found */
         nolig:
-            pos_L_to_V[i] = q - buf_out;
+            pos_L_to_V[i] = (unsigned int)(q - buf_out);
             *q++ = l1;
             i++;
         found:
             ;
         }
     }
-    return q - buf_out;
+    return (int)(q - buf_out);
 }
 
 /* fast classification of unicode chars to optimize the algorithms */
@@ -268,10 +268,10 @@ static int unicode_classify(const char32_t *buf, int len) {
             continue;
         mask |= UNICODE_NONASCII;
         if (c < 0xA00) {
-            if ((c & ~0xff) == 0x600)   /* 0600..06FF */
+            if ((c & ~(char32_t)0xff) == 0x600)   /* 0600..06FF */
                 mask |= UNICODE_ARABIC;
             else
-            if ((c & ~0x7f) == 0x900)   /* 0900..097F */
+            if ((c & ~(char32_t)0x7f) == 0x900)   /* 0900..097F */
                 mask |= UNICODE_INDIC;
         }
     }
@@ -325,7 +325,7 @@ int unicode_to_glyphs(char32_t *dst, unsigned int *char_to_glyph_pos,
         blockcpy(dst, src, len);
         if (char_to_glyph_pos) {
             for (i = 0; i < len; i++)
-                char_to_glyph_pos[i] = i;
+                char_to_glyph_pos[i] = (unsigned int)i;
         }
         return len;
     } else {
@@ -334,7 +334,7 @@ int unicode_to_glyphs(char32_t *dst, unsigned int *char_to_glyph_pos,
         /* init current buffer */
         len = src_size;
         for (i = 0; i < len; i++)
-            ctog[i] = i;
+            ctog[i] = (unsigned int)i;
         blockcpy(buf, src, len);
 
         /* apply each filter */
@@ -356,7 +356,7 @@ int unicode_to_glyphs(char32_t *dst, unsigned int *char_to_glyph_pos,
         if (reverse) {
             bidi_reverse_buf(buf, len);
             for (i = 0; i < src_size; i++) {
-                ctog[i] = len - 1 - ctog[i];
+                ctog[i] = (unsigned int)(len - 1) - ctog[i];
             }
         }
 
@@ -1125,8 +1125,8 @@ void bidir_analyze_string(BidirTypeLink *type_rl_list,
             for (i = 0; i < RL_LEN(pp); i++) {
                 if (stack_index < STACK_SIZE) {
                     /* push level & override */
-                    stack_level[stack_index] = level;
-                    stack_override[stack_index] = override;
+                    stack_level[stack_index] = (unsigned char)level;
+                    stack_override[stack_index] = (unsigned char)override;
                     stack_index++;
                     /* compute new level */
                     if (ONE_OF_2(type, BIDIR_TYPE_LRE, BIDIR_TYPE_LRO)) {

--- a/unix.c
+++ b/unix.c
@@ -343,7 +343,7 @@ void url_redisplay(void)
 }
 
 ssize_t qe_write_timeout(int fd, const char *buf, size_t len, int timeout_ms) {
-    ssize_t ret = len;
+    ssize_t ret = (ssize_t)len;
     while (len > 0) {
         ssize_t res = write(fd, buf, len);
         if (res < 0) {
@@ -365,7 +365,7 @@ ssize_t qe_write_timeout(int fd, const char *buf, size_t len, int timeout_ms) {
         if (res == 0)
             return ret - (ssize_t)len;
         buf += res;
-        len -= res;
+        len -= (size_t)res;
     }
     return ret;
 }

--- a/util.c
+++ b/util.c
@@ -101,7 +101,7 @@ int find_file_next(FindFileState *s, char *filename, int filename_size_max) {
                 p += strcspn(p, ":");
             else
                 p += strlen(p);
-            pstrncpy(s->dirpath, sizeof(s->dirpath), s->bufptr, p - s->bufptr);
+            pstrncpy(s->dirpath, sizeof(s->dirpath), s->bufptr, (int)(p - s->bufptr));
             if (*p == ':')
                 p++;
             s->bufptr = p;
@@ -188,7 +188,7 @@ int is_filepattern(const char *filespec) {
        @note this function only recognises `?` and `*` wildcard characters
      */
     // XXX: should also accept character ranges and {} comprehensions
-    int pos = strcspn(filespec, "*?");
+    int pos = (int)strcspn(filespec, "*?");
     return filespec[pos] != '\0';
 }
 
@@ -213,7 +213,7 @@ static void canonicalize_path1(char *buf, int buf_size, const char *path) {
             if (c == '/')
                 break;
             if ((q - file) < ssizeof(file) - 1)
-                *q++ = c;
+                *q++ = (char)c;
         }
         *q = '\0';
 
@@ -310,12 +310,12 @@ char *make_user_path(char *buf, int buf_size, const char *path) {
      */
     char *homedir = getenv("HOME");
     if (homedir) {
-        int len = strlen(homedir);
+        int len = (int)strlen(homedir);
 
         if (len && homedir[len - 1] == '/')
             len--;
 
-        if (!memcmp(path, homedir, len) && (path[len] == '/' || path[len] == '\0')) {
+        if (!memcmp(path, homedir, (size_t)len) && (path[len] == '/' || path[len] == '\0')) {
             if (buf_size > 1) {
                 *buf = '~';
                 pstrcpy(buf + 1, buf_size - 1, path + len);
@@ -336,7 +336,7 @@ char *reduce_filename(char *dest, int size, const char *filename)
     char *dbase, *ext, *p;
 
     /* Copy path unchanged */
-    pstrncpy(dest, size, filename, base - filename);
+    pstrncpy(dest, size, filename, (int)(base - filename));
 
     /* Strip cvs temp file prefix */
     if (base[0] == '.' && base[1] == '#' && base[2] != '\0')
@@ -354,13 +354,13 @@ char *reduce_filename(char *dest, int size, const char *filename)
         if (*ext != '.')
             break;
         /* keep non numeric extension */
-        if (!qe_isdigit(ext[1]))
+        if (!qe_isdigit((unsigned char)ext[1]))
             break;
         /* keep the last extension */
         if (strchr(dbase, '.') == ext)
             break;
         /* only strip multidigit extensions */
-        if (!qe_isdigit(ext[2]))
+        if (!qe_isdigit((unsigned char)ext[2]))
             break;
         *ext = '\0';
     }
@@ -370,11 +370,11 @@ char *reduce_filename(char *dest, int size, const char *filename)
            Convert all upper case MS/DOS filenames with extension
            to lower case */
         for (p = dbase; *p; p++) {
-            if ((*p & 0x80) || qe_islower(*p))
+            if ((*p & 0x80) || qe_islower((unsigned char)*p))
                 break;
         }
         if (!*p && (p - dbase) <= 12) {
-            qe_strtolower(dbase, dest + size - dbase, dbase);
+            qe_strtolower(dbase, (int)(dest + size - dbase), dbase);
         }
     }
 
@@ -415,14 +415,14 @@ char *file_load(const char *filename, int max_size, int *sizep) {
         errno = ERANGE;
         return NULL;
     }
-    if (!(buf = qe_malloc_array(char, length + 1))) {
+    if (!(buf = qe_malloc_array(char, (size_t)(length + 1)))) {
         fclose(fp);
         errno = ENOMEM;
         return NULL;
     }
 
     fseek(fp, 0, SEEK_SET);
-    length = fread(buf, 1, length, fp);
+    length = (long)fread(buf, 1, (size_t)length, fp);
     buf[length] = '\0';
     fclose(fp);
     if (sizep)
@@ -448,17 +448,17 @@ int match_extension(const char *filename, const char *extlist) {
     base = get_basename(filename);
     while (*base == '.')
         base++;
-    len = strlen(base);
+    len = (int)strlen(base);
     if (len == 0)
         return 0;
 
     for (p = q = extlist;; p++) {
         int c = *p;
         if (c == '|' || c == '\0') {
-            int len1 = p - q;
+            int len1 = (int)(p - q);
             if (len1 != 0 || (q != extlist && c != '\0')) {
                 if (len > len1 && base[len - len1 - 1] == '.'
-                &&  !qe_memicmp(base + (len - len1), q, len1)) {
+                &&  !qe_memicmp(base + (len - len1), q, (size_t)len1)) {
                     return 1;
                 }
             }
@@ -483,23 +483,23 @@ int match_shell_handler(const char *p, const char *list) {
         return 0;
 
     if (p[0] == '#' && p[1] == '!') {
-        for (p += 2; qe_isblank(*p); p++)
+        for (p += 2; qe_isblank((unsigned char)*p); p++)
             continue;
-        for (base = p; *p && !qe_isspace(*p); p++) {
+        for (base = p; *p && !qe_isspace((unsigned char)*p); p++) {
             if (*p == '/')
                 base = p + 1;
         }
-        if (memfind(list, base, p - base))
+        if (memfind(list, base, (int)(p - base)))
             return 1;
         if (p - base == 3 && !memcmp(base, "env", 3)) {
             while (*p && *p != '\n') {
-                for (; qe_isblank(*p); p++)
+                for (; qe_isblank((unsigned char)*p); p++)
                     continue;
                 base = p;
-                for (; *p && !qe_isspace(*p); p++)
+                for (; *p && !qe_isspace((unsigned char)*p); p++)
                     continue;
                 if (*base != '-')
-                    return memfind(list, base, p - base);
+                    return memfind(list, base, (int)(p - base));
             }
         }
     }
@@ -513,7 +513,7 @@ int remove_slash(char *buf) {
      */
     // XXX: should we have windows specific behavior?
     // XXX: should we handle protocol prefixes specifically?
-    int len = strlen(buf);
+    int len = (int)strlen(buf);
     if (len > 1 && buf[len - 1] == '/') {
         buf[--len] = '\0';
     }
@@ -527,7 +527,7 @@ int append_slash(char *buf, int buf_size) {
        @note: truncation cannot be detected reliably
      */
     // XXX: should we have windows specific behavior?
-    int len = strnlen(buf, buf_size);
+    int len = (int)strnlen(buf, (size_t)buf_size);
     if (len > 0 && buf[len - 1] != '/' && len + 1 < buf_size) {
         buf[len++] = '/';
         buf[len] = '\0';
@@ -559,7 +559,7 @@ void splitpath(char *dirname, int dirname_size,
      */
     size_t offset = get_basename_offset(pathname);
     if (dirname)
-        pstrncpy(dirname, dirname_size, pathname, offset);
+        pstrncpy(dirname, dirname_size, pathname, (int)offset);
     if (filename)
         pstrcpy(filename, filename_size, pathname + offset);
 }
@@ -587,7 +587,7 @@ int qe_skip_spaces(const char **pp) {
     unsigned char c;
 
     p = *pp;
-    while (qe_isspace(c = *p))
+    while (qe_isspace(c = (unsigned char)*p))
         p++;
     *pp = p;
     return c;
@@ -630,7 +630,7 @@ int qe_strcollate(const char *s1, const char *s2) {
         res = (c1 < c2) ? -1 : 1;
 
     for (;;) {
-        flags = qe_isdigit(c1) * 2 + qe_isdigit(c2);
+        flags = qe_isdigit((unsigned int)c1) * 2 + qe_isdigit((unsigned int)c2);
         if (flags == 3) {
             last = c1;
             c1 = (unsigned char)*s1++;
@@ -639,7 +639,7 @@ int qe_strcollate(const char *s1, const char *s2) {
             break;
         }
     }
-    if (!qe_isdigit(last) || flags == 0)
+    if (!qe_isdigit((unsigned int)last) || flags == 0)
         return res;
     return (flags == 1) ? -1 : 1;
 }
@@ -676,8 +676,8 @@ void qe_strtolower(char *buf, int size, const char *str) {
     unsigned char c;
 
     if (size > 0) {
-        while ((c = *str++) != '\0' && size > 1) {
-            *buf++ = qe_tolower(c);
+        while ((c = (unsigned char)*str++) != '\0' && size > 1) {
+            *buf++ = (char)qe_tolower(c);
             size--;
         }
         *buf = '\0';
@@ -741,7 +741,7 @@ int strfind(const char *keytable, const char *str) {
        @argument `str` a valid string pointer.
        @return 1 if there is a match, 0 otherwise.
      */
-    return memfind(keytable, str, strlen(str));
+    return memfind(keytable, str, (int)strlen(str));
 }
 
 int strxfind(const char *list, const char *s) {
@@ -774,10 +774,10 @@ int strxfind(const char *list, const char *s) {
         p = (const u8*)s;
         for (;;) {
             do {
-                c1 = qe_toupper(*p++);
+                c1 = (u8)qe_toupper(*p++);
             } while (c1 == '-' || c1 == '_' || c1 == ' ');
             do {
-                c2 = qe_toupper(*q++);
+                c2 = (u8)qe_toupper(*q++);
             } while (c2 == '-' || c2 == '_' || c2 == ' ');
             if (c1 == '\0') {
                 if (c2 == '\0' || c2 == '|')
@@ -823,13 +823,13 @@ const char *strmem(const char *str, const void *mem, int size) {
     }
 
     // XXX: problem if match is a suffix
-    len = strlen(str);
+    len = (int)strlen(str);
     if (size >= len)
         return NULL;
 
     str_max = str + len - size;
     for (p = str; p < str_max; p++) {
-        if (*p == c && !memcmp(p + 1, p1, size))
+        if (*p == c && !memcmp(p + 1, p1, (size_t)size))
             return p;
     }
     return NULL;
@@ -849,20 +849,20 @@ const void *memstr(const void *buf, int size, const char *str) {
     int len;
     const u8 *p, *buf_max;
 
-    c = *str++;
+    c = (u8)*str++;
     if (!c) {
         /* empty string matches start of buffer */
         return buf;
     }
 
     // XXX: problem if match is a suffix
-    len = strlen(str);
+    len = (int)strlen(str);
     if (len >= size)
         return NULL;
 
     buf_max = (const u8*)buf + size - len;
     for (p = buf; p < buf_max; p++) {
-        if (*p == c && !memcmp(p + 1, str, len))
+        if (*p == c && !memcmp(p + 1, str, (size_t)len))
             return p;
     }
     return NULL;
@@ -884,8 +884,8 @@ int qe_memicmp(const void *p1, const void *p2, size_t count) {
 
     for (; count-- > 0; s1++, s2++) {
         if (*s1 != *s2) {
-            u8 c1 = qe_toupper(*s1);
-            u8 c2 = qe_toupper(*s2);
+            u8 c1 = (u8)qe_toupper(*s1);
+            u8 c2 = (u8)qe_toupper(*s2);
             if (c1 != c2)
                 return (c2 < c1) - (c1 < c2);
         }
@@ -906,19 +906,19 @@ const char *qe_stristr(const char *s1, const char *s2) {
     u8 c, c1, c2;
     int len;
 
-    len = strlen(s2);
+    len = (int)strlen(s2);
     if (!len)
         return s1;
 
-    c = *s2++;
+    c = (u8)*s2++;
     len--;
-    c1 = qe_toupper(c);
-    c2 = qe_tolower(c);
+    c1 = (u8)qe_toupper(c);
+    c2 = (u8)qe_tolower(c);
 
-    while ((c = *s1++) != '\0') {
+    while ((c = (u8)*s1++) != '\0') {
         if (c == c1 || c == c2) {
             // XXX: not strictly correct as s2 might be shorter than len
-            if (!qe_memicmp(s1, s2, len))
+            if (!qe_memicmp(s1, s2, (size_t)len))
                 return s1 - 1;
         }
     }
@@ -997,9 +997,9 @@ int strxcmp(const char *str1, const char *str2) {
        of `str1 <=> str2`
      */
     for (;;) {
-        u8 c1 = *str1;
-        u8 c2 = *str2;
-        int d = qe_toupper(c1) - qe_toupper(c2);
+        u8 c1 = (u8)*str1;
+        u8 c2 = (u8)*str2;
+        int d = (int)qe_toupper(c1) - (int)qe_toupper(c2);
         if (d) {
             if (c2 == '-' || c2 == '_' || c2 == ' ') {
                 str2++;
@@ -1054,18 +1054,18 @@ int strmatch_pat(const char *str, const char *pat, int start) {
      */
     u8 c1, c2;
     while (*pat) {
-        c1 = *pat++;
+        c1 = (u8)*pat++;
         if (c1 == '*') {
-            c1 = *pat++;
+            c1 = (u8)*pat++;
             if (c1 == '\0')
                 return 1;
-            while ((c2 = *str++) != '\0') {
+            while ((c2 = (u8)*str++) != '\0') {
                 if (c1 == c2 && strmatch_pat(str, pat, start))
                     return 1;
             }
             return 0;
         } else {
-            c2 = *str++;
+            c2 = (u8)*str++;
             if (c1 != c2)
                 return 0;
         }
@@ -1087,7 +1087,7 @@ int utf8_strimatch_pat(const char *str, const char *pat, int start) {
      */
     char32_t c1, c2;
     while (*pat) {
-        c1 = *pat++;
+        c1 = (unsigned char)*pat++;
         if (c1 & 0x80) {
             pat--;
             do {
@@ -1096,7 +1096,7 @@ int utf8_strimatch_pat(const char *str, const char *pat, int start) {
             c1 = qe_unaccent(c1);
         }
         if (c1 == '*') {
-            c1 = *pat++;
+            c1 = (unsigned char)*pat++;
             if (c1 & 0x80) {
                 pat--;
                 do {
@@ -1106,7 +1106,7 @@ int utf8_strimatch_pat(const char *str, const char *pat, int start) {
             }
             if (c1 == '\0')
                 return 1;
-            while ((c2 = *str++) != '\0') {
+            while ((c2 = (unsigned char)*str++) != '\0') {
                 if (c2 & 0x80) {
                     str--;
                     do {
@@ -1120,7 +1120,7 @@ int utf8_strimatch_pat(const char *str, const char *pat, int start) {
             }
             return 0;
         } else {
-            c2 = *str++;
+            c2 = (unsigned char)*str++;
             if (c2 & 0x80) {
                 str--;
                 do {
@@ -1155,12 +1155,12 @@ int get_str(const char **pp, char *buf, int buf_size, const char *stop) {
     qe_skip_spaces(pp);
     p = *pp;
     for (i = 0;;) {
-        u8 c = *p;
+        u8 c = (u8)*p;
         /* Stop on spaces and eat them */
-        if (qe_isspace(c) || strchr(stop, c))
+        if (qe_isspace(c) || strchr(stop, (int)c))
             break;
         if (i + 1 < buf_size)
-            buf[i++] = c;
+            buf[i++] = (char)c;
         p++;
     }
     if (i < buf_size)
@@ -1222,7 +1222,7 @@ static const char *sreg_skip(const char *p, int iter) {
     /* skip past en enumeration */
     int level = 0;
     while (*p != '\0') {
-        u8 c = *p++;
+        u8 c = (u8)*p++;
         if (c == '(') {
             level++;
         } else
@@ -1250,12 +1250,12 @@ static const char *sreg_match_class(const char *p, const char *re, const char *e
     int not = *re == '^';
     u8 c, c1, c2;
     re += not;
-    c = *p++;
+    c = (u8)*p++;
     while (re < end) {
-        c2 = c1 = *re++;
+        c2 = c1 = (u8)*re++;
         if (*re == '-' && re + 1 < end) {
             re++;
-            c2 = *re++;
+            c2 = (u8)*re++;
         }
         if (c >= c1 && c <= c2)
             return p;
@@ -1416,7 +1416,7 @@ int utf8_prefix_len(const char *str1, const char *str2) {
             str2++;
         }
     }
-    return str1 - start;
+    return (int)(str1 - start);
 }
 
 int ustrstart(const char32_t *str0, const char *val, int *lenp) {
@@ -1442,7 +1442,7 @@ int ustrstart(const char32_t *str0, const char *val, int *lenp) {
             return 0;
     }
     if (lenp)
-        *lenp = str - str0;
+        *lenp = (int)(str - str0);
     return 1;
 }
 
@@ -1454,7 +1454,7 @@ const char32_t *ustrstr(const char32_t *str, const char *val) {
        @return a pointer to the first code point of the match if found,
        `NULL` otherwise.
      */
-    char32_t c = val[0];
+    char32_t c = (unsigned char)val[0];
 
     for (; *str != '\0'; str++) {
         if (*str == c && ustrstart(str, val, NULL))
@@ -1487,7 +1487,7 @@ int ustristart(const char32_t *str0, const char *val, int *lenp) {
             return 0;
     }
     if (lenp)
-        *lenp = str - str0;
+        *lenp = (int)(str - str0);
     return 1;
 }
 
@@ -1819,7 +1819,7 @@ static int strtokey1(const char **pp)
 #endif
     /* Should also support backslash escapes: \000 \x00 \u0000 */
     /* Should also support ^x and syntax and Ctrl- prefix for control keys */
-    key = utf8_decode(&p);
+    key = (int)utf8_decode(&p);
     // XXX: Should assume unknown function key if p != p1 */
     // FIXME: this breaks string macros: "Hello SPC world! RET" @@@
     if (p != p1)
@@ -1882,7 +1882,7 @@ int strtokey(const char **pp)
             *pp = p;
             return KEY_UNKNOWN;
         } else {
-            key = utf8_decode(&p);
+            key = (int)utf8_decode(&p);
             break;
         }
     }
@@ -1900,7 +1900,7 @@ int strtokeys(const char *str, unsigned int *keys,
 
     while (qe_skip_spaces(&p)) {
         key = strtokey(&p);
-        keys[nb_keys++] = key;
+        keys[nb_keys++] = (unsigned int)key;
         compose_keys(keys, &nb_keys);
         if (*p == ',' && p[1] == ' ') {
             p += 2;
@@ -1945,9 +1945,9 @@ int buf_put_key(buf_t *out, int key) {
     } else
         // FIXME: handle @-_  @@@
     if (key >= KEY_CTRL('@') && key <= KEY_CTRL('_')) {
-        buf_printf(out, "C-%c", (int)qe_tolower(key + 'A' - 1));
+        buf_printf(out, "C-%c", (int)qe_tolower((unsigned int)(key + 'A' - 1)));
     } else {
-        buf_putc_utf8(out, key);
+        buf_putc_utf8(out, (unsigned int)key);
     }
     return out->len - start;
 }
@@ -1967,13 +1967,13 @@ int buf_put_keys(buf_t *out, unsigned int *keys, int nb_keys)
     for (i = 0; i < nb_keys; i++) {
         if (i != 0)
             buf_put_byte(out, ' ');
-        buf_put_key(out, keys[i]);
+        buf_put_key(out, (int)keys[i]);
     }
     return out->len - start;
 }
 
 int is_shift_key(int key) {
-    return qe_isupper(key) || KEY_IS_SHIFT(key);
+    return qe_isupper((unsigned int)key) || KEY_IS_SHIFT(key);
 }
 
 /*---- StringArray functions ----*/
@@ -1988,13 +1988,13 @@ StringItem *set_string(StringArray *cs, int index, const char *str, int group)
     if (!cs || index < 0 || index >= cs->nb_items)
         return NULL;
 
-    len = strlen(str);
+    len = (int)strlen(str);
     v = qe_malloc_hack(StringItem, len);
     if (!v)
         return NULL;
     v->selected = 0;
-    v->group = group;
-    memcpy(v->str, str, len + 1);
+    v->group = (char)group;
+    memcpy(v->str, str, (size_t)(len + 1));
     if (cs->items[index])
         qe_free(&cs->items[index]);
     cs->items[index] = v;
@@ -2033,7 +2033,7 @@ int remove_string(StringArray *cs, const char *str) {
 
 void sort_strings(StringArray *cs, int (*sort_func)(const void *p1, const void *p2))
 {
-    qsort(cs->items, cs->nb_items, sizeof(StringItem *), sort_func);
+    qsort(cs->items, (size_t)cs->nb_items, sizeof(StringItem *), sort_func);
 }
 
 int remove_duplicate_strings(StringArray *cs) {
@@ -2079,7 +2079,7 @@ int buf_write(buf_t *bp, const void *src, int size)
         n = bp->size - bp->pos - 1;
         if (n > size)
             n = size;
-        memcpy(bp->buf + bp->len, src, n);
+        memcpy(bp->buf + bp->len, src, (size_t)n);
         bp->len += n;
         bp->buf[bp->len] = '\0';
     }
@@ -2106,7 +2106,7 @@ int buf_printf(buf_t *bp, const char *fmt, ...)
         size = bp->size - bp->pos;
     }
     va_start(ap, fmt);
-    len = vsnprintf(dest, size, fmt, ap);
+    len = vsnprintf(dest, (size_t)size, fmt, ap);
     va_end(ap);
 
     if (bp->pos < bp->size) {
@@ -2130,7 +2130,7 @@ int buf_putc_utf8(buf_t *bp, char32_t c)
     if (c < 0x80) {
         bp->pos++;
         if (bp->pos < bp->size) {
-            bp->buf[bp->len++] = c;
+            bp->buf[bp->len++] = (char)c;
             bp->buf[bp->len] = '\0';
             return 1;
         } else {
@@ -2143,7 +2143,7 @@ int buf_putc_utf8(buf_t *bp, char32_t c)
         len = utf8_encode(buf, c);
         /* avoid appending a partial UTF-8 sequence */
         if (bp->pos + len < bp->size) {
-            memcpy(bp->buf + bp->len, buf, len);
+            memcpy(bp->buf + bp->len, buf, (size_t)len);
             bp->pos += len;
             bp->len += len;
             bp->buf[bp->len] = '\0';
@@ -2164,7 +2164,7 @@ int strsubst(char *buf, int buf_size, const char *from,
 
     p = from;
     while ((q = strstr(p, s1)) != NULL) {
-        buf_write(out, p, q - p);
+        buf_write(out, p, (int)(q - p));
         buf_puts(out, s2);
         p = q + strlen(s1);
     }
@@ -2192,18 +2192,18 @@ int byte_quote(char *dest, int size, unsigned char ch) {
     ||  ((void)(c = '\''), ch == '\'')      // XXX: need flag to make this optional
     ||  ((void)(c = '\"'), ch == '\"')      // XXX: need flag to make this optional
     ||  ((void)(c = '\\'), ch == '\\')) {
-        return snprintf(dest, size, "\\%c", c);
+        return snprintf(dest, (size_t)size, "\\%c", c);
     } else
     if (ch < 32) {
         //if (*p == '\e' && col > 9) {
         //    eb_write(b, b->total_size, "\n         ", 10);
         //    col = 9;
         //}
-        return snprintf(dest, size, "\\^%c", (ch + '@') & 127);      // XXX: need flag to make this optional
+        return snprintf(dest, (size_t)size, "\\^%c", (ch + '@') & 127);      // XXX: need flag to make this optional
     } else
     if (ch < 127) {
         if (size > 1) {
-            dest[0] = ch;
+            dest[0] = (char)ch;
             dest[1] = '\0';
         } else
         if (size > 0) {
@@ -2211,7 +2211,7 @@ int byte_quote(char *dest, int size, unsigned char ch) {
         }
         return 1;
     } else {
-        return snprintf(dest, size, "\\0x%02X", ch);      // XXX: need flag to make this optional
+        return snprintf(dest, (size_t)size, "\\0x%02X", ch);      // XXX: need flag to make this optional
     }
 }
 
@@ -2232,10 +2232,10 @@ int strquote(char *dest, int size, const char *str, int len) {
     if (str) {
         int i;
         if (len < 0)
-            len = strlen(str);
+            len = (int)strlen(str);
         buf_put_byte(out, '"');
         for (i = 0; i < len; i++)
-            buf_quote_byte(out, str[i]);
+            buf_quote_byte(out, (unsigned char)str[i]);
         buf_put_byte(out, '"');
     } else {
         buf_puts(out, "null");
@@ -2354,18 +2354,18 @@ void *qe_decode64(const char *src, size_t len, size_t *sizep)
                 continue;
             switch (shift++ & 3) {
             case 0:
-                buf[j] = val << 2;
+                buf[j] = (u8)(val << 2);
                 break;
             case 1:
-                buf[j++] |= val >> 4;
-                buf[j] = (val << 4) & 0xff;
+                buf[j++] |= (u8)(val >> 4);
+                buf[j] = (u8)((val << 4) & 0xff);
                 break;
             case 2:
-                buf[j++] |= val >> 2;
-                buf[j] = (val << 6) & 0xff;
+                buf[j++] |= (u8)(val >> 2);
+                buf[j] = (u8)((val << 6) & 0xff);
                 break;
             case 3:
-                buf[j++] |= val;
+                buf[j++] |= (u8)val;
                 break;
             }
         }
@@ -2482,7 +2482,7 @@ bstr_t bstr_get_nth(const char *s, int n) {
     for (bs.s = s;; s++) {
         if (*s == '\0' || *s == '|') {
             if (n-- == 0) {
-                bs.len = s - bs.s;
+                bs.len = (int)(s - bs.s);
                 break;
             }
             if (*s) {
@@ -2506,7 +2506,7 @@ bstr_t bstr_token(const char *s, int sep, const char **pp) {
         for (; *s != '\0' && *s != sep; s++)
             continue;
 
-        bs.len = s - bs.s;
+        bs.len = (int)(s - bs.s);
     }
     if (pp) {
         *pp = (s && *s) ? s + 1 : NULL;
@@ -2869,32 +2869,32 @@ int utf8_encode(char *q0, char32_t c) {
     char *q = q0;
 
     if (c < 0x80) {
-        *q++ = c;
+        *q++ = (char)c;
     } else {
         if (c < 0x800) {
-            *q++ = (c >> 6) | 0xc0;
+            *q++ = (char)((c >> 6) | 0xc0);
         } else {
             if (c < 0x10000) {
-                *q++ = (c >> 12) | 0xe0;
+                *q++ = (char)((c >> 12) | 0xe0);
             } else {
                 if (c < 0x00200000) {
-                    *q++ = (c >> 18) | 0xf0;
+                    *q++ = (char)((c >> 18) | 0xf0);
                 } else {
                     if (c < 0x04000000) {
-                        *q++ = (c >> 24) | 0xf8;
+                        *q++ = (char)((c >> 24) | 0xf8);
                     } else {
-                        *q++ = (c >> 30) | 0xfc;
-                        *q++ = ((c >> 24) & 0x3f) | 0x80;
+                        *q++ = (char)((c >> 30) | 0xfc);
+                        *q++ = (char)(((c >> 24) & 0x3f) | 0x80);
                     }
-                    *q++ = ((c >> 18) & 0x3f) | 0x80;
+                    *q++ = (char)(((c >> 18) & 0x3f) | 0x80);
                 }
-                *q++ = ((c >> 12) & 0x3f) | 0x80;
+                *q++ = (char)(((c >> 12) & 0x3f) | 0x80);
             }
-            *q++ = ((c >> 6) & 0x3f) | 0x80;
+            *q++ = (char)(((c >> 6) & 0x3f) | 0x80);
         }
-        *q++ = (c & 0x3f) | 0x80;
+        *q++ = (char)((c & 0x3f) | 0x80);
     }
-    return q - q0;
+    return (int)(q - q0);
 }
 
 int utf8_to_char32(char32_t *dest, int dest_length, const char *str)

--- a/util.h
+++ b/util.h
@@ -340,7 +340,7 @@ static inline int qe_findchar(const char *str, char32_t c) {
        the string, `0` if `c` is `0` or non-ASCII or was not found in the set.
        @note: only ASCII characters are supported
      */
-    return qe_inrange(c, 1, 127) && strchr(str, c) != NULL;
+    return qe_inrange(c, 1, 127) && strchr(str, (int)c) != NULL;
 }
 
 static inline int qe_indexof(const char *str, char32_t c) {
@@ -354,7 +354,7 @@ static inline int qe_indexof(const char *str, char32_t c) {
        Contrary to `strchr`, `'\0'` is never found in the set.
      */
     if (qe_inrange(c, 1, 127)) {
-        const char *p = strchr(str, c);
+        const char *p = strchr(str, (int)c);
         if (p) return (int)(p - str);
     }
     return -1;
@@ -644,7 +644,7 @@ static inline int buf_put_byte(buf_t *bp, unsigned char ch) {
        @return the number of bytes actually written.
      */
     if (bp->pos + 1 < bp->size) {
-        bp->buf[bp->len++] = ch;
+        bp->buf[bp->len++] = (char)ch;
         bp->buf[bp->len] = '\0';
     }
     return bp->pos++;
@@ -659,7 +659,7 @@ static inline int buf_puts(buf_t *bp, const char *str) {
        @argument `str` a valid pointer to a C string
        @return the number of bytes actually written.
      */
-    return buf_write(bp, str, strlen(str));
+    return buf_write(bp, str, (int)strlen(str));
 }
 
 int buf_printf(buf_t *bp, const char *fmt, ...) qe__attr_printf(2,3);
@@ -672,7 +672,7 @@ typedef struct bstr_t {
 } bstr_t;
 
 static inline bstr_t bstr_make(const char *s) {
-    bstr_t bs = { s, s ? strlen(s) : 0 };
+    bstr_t bs = { s, s ? (int)strlen(s) : 0 };
     return bs;
 }
 
@@ -681,7 +681,7 @@ bstr_t bstr_get_nth(const char *s, int n);
 
 static inline int bstr_equal(bstr_t s1, bstr_t s2) {
     /* NULL and empty strings are equivalent */
-    return s1.len == s2.len && !memcmp(s1.s, s2.s, s1.len);
+    return s1.len == s2.len && !memcmp(s1.s, s2.s, (size_t)s1.len);
 }
 
 /*---- our own implementation of qsort_r() ----*/
@@ -846,11 +846,11 @@ static inline int qe_iswalpha(char32_t c) {
     return qe_isalpha(qe_unaccent(c));
 }
 
-static inline char32_t qe_iswlower(char32_t c) {
+static inline int qe_iswlower(char32_t c) {
     return qe_islower(qe_unaccent(c));
 }
 
-static inline char32_t qe_iswupper(char32_t c) {
+static inline int qe_iswupper(char32_t c) {
     return qe_isupper(qe_unaccent(c));
 }
 

--- a/util.h
+++ b/util.h
@@ -538,12 +538,12 @@ void qe_free(T **pp);
 #define qe_malloc(t)            ((t *)qe_malloc_bytes(sizeof(t)))
 #define qe_mallocz(t)           ((t *)qe_mallocz_bytes(sizeof(t)))
 /* Overflow-safe array allocators: safe_mul returns 0 on overflow → NULL */
-#define qe_malloc_array(t, n)   ((t *)qe_malloc_bytes(safe_mul((n), sizeof(t))))
-#define qe_mallocz_array(t, n)  ((t *)qe_mallocz_bytes(safe_mul((n), sizeof(t))))
-#define qe_malloc_hack(t, n)    ((t *)qe_malloc_bytes(sizeof(t) + (n)))
-#define qe_mallocz_hack(t, n)   ((t *)qe_mallocz_bytes(sizeof(t) + (n)))
-#define qe_malloc_dup_array(p, n)  (qe_malloc_dup_bytes(p, safe_mul((n), sizeof(*(p)))))
-#define qe_realloc_array(pp, n)  (qe_realloc_bytes(pp, safe_mul((n), sizeof(**(pp)))))
+#define qe_malloc_array(t, n)   ((t *)qe_malloc_bytes(safe_mul((size_t)(n), sizeof(t))))
+#define qe_mallocz_array(t, n)  ((t *)qe_mallocz_bytes(safe_mul((size_t)(n), sizeof(t))))
+#define qe_malloc_hack(t, n)    ((t *)qe_malloc_bytes(sizeof(t) + (size_t)(n)))
+#define qe_mallocz_hack(t, n)   ((t *)qe_mallocz_bytes(sizeof(t) + (size_t)(n)))
+#define qe_malloc_dup_array(p, n)  (qe_malloc_dup_bytes(p, safe_mul((size_t)(n), sizeof(*(p)))))
+#define qe_realloc_array(pp, n)  (qe_realloc_bytes(pp, safe_mul((size_t)(n), sizeof(**(pp)))))
 
 #if 1  // to test clang -Weverything
 #define qe_free(pp)    do { void *_1 = (pp), **_2 = _1; (free)(*_2); *_2 = NULL; } while (0)

--- a/variables.c
+++ b/variables.c
@@ -203,7 +203,7 @@ QVarType qe_get_variable(EditState *s, const char *name,
                 *buf = '\0';
             return VAR_UNKNOWN;
         }
-        num = strtol_c(str, &endp, 0);
+        num = (int)strtol_c(str, &endp, 0);
         if (pnum && endp != str && *endp == '\0') {
             *pnum = num;
             return VAR_NUMBER;
@@ -259,7 +259,7 @@ QVarType qe_get_variable(EditState *s, const char *name,
         if (pnum)
             *pnum = num;
         else
-            snprintf(buf, size, "%d", num);
+            snprintf(buf, (size_t)size, "%d", num);
         break;
     default:
         if (size > 0)
@@ -386,7 +386,7 @@ QVarType qe_set_variable(EditState *s, const char *name,
         }
         if (vp->type == VAR_NUMBER && value) {
             const char *p;
-            num = strtol_c(value, &p, 0);
+            num = (int)strtol_c(value, &p, 0);
             if (!*p)
                 value = NULL;
         }


### PR DESCRIPTION
## Summary

- Add explicit casts throughout the codebase to fix ~2976 `-Wsign-conversion` and `-Wconversion` warnings
- Suppress warnings for vendored code (`libunicode.c`, `libregexp.c`, `lua-amalg.c`) via per-target Makefile flags
- Fix type mismatches in core headers (`cutils.h`, `util.h`, `qe.h`, `color.h`) — highest-impact since headers are included everywhere
- Work in progress: ~300 warnings remain across lang/ and modes/ files; more commits incoming

## Once complete

The two `-Wno-error=sign-conversion -Wno-error=conversion` carve-outs in `Makefile` will be removed, making any future regression a build error (via the existing `-Werror` flag).

## Test plan

- [ ] `make` succeeds with 0 warnings
- [ ] `make clean && make` succeeds with 0 errors and 0 warnings  
- [ ] `make test` passes

https://claude.ai/code/session_014jHBwj7mxvajvoMAFF8XTF