### PR TITLE
Enable additional compiler warnings for correctness and safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ CFLAGS += -Wnull-dereference
 CFLAGS += -Wdouble-promotion
 CFLAGS += -Wimplicit-fallthrough
 CFLAGS += -Wsign-conversion -Wconversion
+CFLAGS += -Wundef -Wvla -Wpointer-arith -Wcast-qual
+CFLAGS += -Wbad-function-cast -Wnested-externs -Winit-self
+CFLAGS += -Wduplicated-cond -Wrestrict
 # Runtime buffer overflow detection for libc functions
 CFLAGS += -D_FORTIFY_SOURCE=2
 CFLAGS += -I.
@@ -259,7 +262,7 @@ $(OBJS_DIR)/libqhtml/xmlparse.o: libqhtml/xmlparse.c libqhtml/css.h libqhtml/htm
 $(OBJS_DIR)/third_party/lua/lua-amalg.o: third_party/lua/lua-amalg.c third_party/lua/lua-amalg.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC -c $<
 	$(cmd)  mkdir -p $(dir $@)
-	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -Wno-sign-conversion -Wno-conversion -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -Wno-sign-conversion -Wno-conversion -Wno-bad-function-cast -Wno-cast-qual -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 
 $(OBJS_DIR)/%.o: %.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<

--- a/buffer.c
+++ b/buffer.c
@@ -1272,7 +1272,7 @@ void do_undo(EditState *s)
         put_status(s, "Undo!");
     }
     if (!qs->first_transient_key
-    &&  (qs->last_key == 'u' || qs->last_key == 'u')) {
+    &&  qs->last_key == 'u') {
         put_status(s, "Repeat with 'u', 'r'");
         qe_register_transient_binding(qs, "undo", "u");
         qe_register_transient_binding(qs, "redo", "r");

--- a/indic.c
+++ b/indic.c
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-#include "cutils.h"
+#include "util.h"
 #include "unicode_join.h"
 
 #define VIRAMA  0x94d
@@ -61,8 +61,10 @@ static int devanagari_is_dead_consonant(char32_t i) {
 int devanagari_log2vis(char32_t *str, unsigned int *ctog, int len) {
     char32_t cc, c;
     int i, len1, j, k;
-    /* CG: C99 variable-length arrays may be too large */
-    char32_t *q, buf[len];
+    char32_t *q, *buf = qe_malloc_array(char32_t, len);
+
+    if (!buf)
+        return len;
 
     /* Rule 1: dead consonant rule */
     q = buf;
@@ -139,5 +141,6 @@ int devanagari_log2vis(char32_t *str, unsigned int *ctog, int len) {
             ctog[i] = (unsigned int)k;
         }
     }
+    qe_free(&buf);
     return j;
 }

--- a/unicode_join.c
+++ b/unicode_join.c
@@ -186,9 +186,14 @@ static int unicode_ligature(char32_t *buf_out,
     char32_t l1, l2;
     char32_t *q;
     const unsigned short *lig;
-    /* CG: C99 variable-length arrays may be too large */
-    // XXX: why do we need a local copy?
-    char32_t buf[len];
+    char32_t *buf;
+
+    if (len <= 0)
+        return len;
+
+    buf = qe_malloc_array(char32_t, len);
+    if (!buf)
+        return len;
 
     blockcpy(buf, buf_out, len);
 
@@ -250,6 +255,7 @@ static int unicode_ligature(char32_t *buf_out,
             ;
         }
     }
+    qe_free(&buf);
     return (int)(q - buf_out);
 }
 
@@ -312,10 +318,8 @@ int unicode_to_glyphs(char32_t *dst, unsigned int *char_to_glyph_pos,
                       int reverse)
 {
     int len, i;
-    /* CG: C99 variable-length arrays may be too large */
-    unsigned int ctog[src_size];
-    unsigned int ctog1[src_size];
-    char32_t buf[src_size];
+    unsigned int *ctog, *ctog1;
+    char32_t *buf;
     int unicode_class;
 
     unicode_class = unicode_classify(src, src_size);
@@ -328,46 +332,63 @@ int unicode_to_glyphs(char32_t *dst, unsigned int *char_to_glyph_pos,
                 char_to_glyph_pos[i] = (unsigned int)i;
         }
         return len;
-    } else {
-        /* generic case */
+    }
 
-        /* init current buffer */
-        len = src_size;
-        for (i = 0; i < len; i++)
-            ctog[i] = (unsigned int)i;
-        blockcpy(buf, src, len);
+    /* generic case */
+    if (src_size <= 0)
+        return 0;
 
-        /* apply each filter */
+    ctog = qe_malloc_array(unsigned int, src_size);
+    ctog1 = qe_malloc_array(unsigned int, src_size);
+    buf = qe_malloc_array(char32_t, src_size);
+    if (!ctog || !ctog1 || !buf) {
+        qe_free(&ctog);
+        qe_free(&ctog1);
+        qe_free(&buf);
+        len = min_int(src_size, dst_size);
+        blockcpy(dst, src, len);
+        return len;
+    }
 
-        if (unicode_class & UNICODE_ARABIC) {
-            len = arabic_join(buf, ctog1, len);
-            /* not needed for arabic_join */
-            //compose_char_to_glyph(ctog, src_size, ctog1);
-        }
+    /* init current buffer */
+    len = src_size;
+    for (i = 0; i < len; i++)
+        ctog[i] = (unsigned int)i;
+    blockcpy(buf, src, len);
 
-        if (unicode_class & UNICODE_INDIC) {
-            len = devanagari_log2vis(buf, ctog1, len);
-            compose_char_to_glyph(ctog, src_size, ctog1);
-        }
+    /* apply each filter */
 
-        len = unicode_ligature(buf, ctog1, len);
+    if (unicode_class & UNICODE_ARABIC) {
+        len = arabic_join(buf, ctog1, len);
+        /* not needed for arabic_join */
+        //compose_char_to_glyph(ctog, src_size, ctog1);
+    }
+
+    if (unicode_class & UNICODE_INDIC) {
+        len = devanagari_log2vis(buf, ctog1, len);
         compose_char_to_glyph(ctog, src_size, ctog1);
+    }
 
-        if (reverse) {
-            bidi_reverse_buf(buf, len);
-            for (i = 0; i < src_size; i++) {
-                ctog[i] = (unsigned int)(len - 1) - ctog[i];
-            }
-        }
+    len = unicode_ligature(buf, ctog1, len);
+    compose_char_to_glyph(ctog, src_size, ctog1);
 
-        if (len > dst_size)
-            len = dst_size;
-        blockcpy(dst, buf, len);
-
-        if (char_to_glyph_pos) {
-            blockcpy(char_to_glyph_pos, ctog, src_size);
+    if (reverse) {
+        bidi_reverse_buf(buf, len);
+        for (i = 0; i < src_size; i++) {
+            ctog[i] = (unsigned int)(len - 1) - ctog[i];
         }
     }
+
+    if (len > dst_size)
+        len = dst_size;
+    blockcpy(dst, buf, len);
+
+    if (char_to_glyph_pos) {
+        blockcpy(char_to_glyph_pos, ctog, src_size);
+    }
+    qe_free(&ctog);
+    qe_free(&ctog1);
+    qe_free(&buf);
     return len;
 }
 


### PR DESCRIPTION
Add -Wundef, -Wvla, -Wpointer-arith, -Wcast-qual, -Wbad-function-cast,
-Wnested-externs, -Winit-self, -Wduplicated-cond, and -Wrestrict to
catch more bugs at compile time.

Fix warnings uncovered by the new flags:
- buffer.c: remove duplicate condition in undo transient key check
  (-Wlogical-op found: `last_key == 'u' || last_key == 'u'`)
- unicode_join.c: replace VLAs with heap allocation (qe_malloc_array)
  to eliminate stack overflow risk with large inputs
- indic.c: replace VLA with heap allocation (qe_malloc_array)

Suppress -Wbad-function-cast and -Wcast-qual for vendored Lua code.

Flags evaluated but not enabled:
- -Wlogical-op: false positives on EAGAIN==EWOULDBLOCK POSIX idiom
- -Wjump-misses-init: too many hits in syntax highlighter goto patterns
- -Wfloat-equal: 21 warnings across codebase, needs separate cleanup
- -Wduplicated-branches: 130 warnings, mostly in generated/vendored code
- -Wstringop-overflow: false positives with heap-allocated buffers
- -fstack-protector-strong: incompatible with cosmopolitan libc

https://claude.ai/code/session_0184YnqDB2Nju1tJpEQhW1p8