### PR TITLE
Enable -Wlogical-op, -Wjump-misses-init, -Wfloat-equal, -Wduplicated-branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,17 @@ CFLAGS += -Wsign-conversion -Wconversion
 CFLAGS += -Wundef -Wvla -Wpointer-arith -Wcast-qual
 CFLAGS += -Wbad-function-cast -Wnested-externs -Winit-self
 CFLAGS += -Wduplicated-cond -Wrestrict
+# Catch logical mistakes: duplicate conditions, skipped initializations, float compares
+CFLAGS += -Wlogical-op
+CFLAGS += -Wjump-misses-init
+CFLAGS += -Wfloat-equal
+CFLAGS += -Wduplicated-branches
+# -Wstringop-overflow: disabled — GCC emits false positives for dynamic heap buffers
+# (array bounds inferred as [0] when allocated via malloc, triggering spurious truncation warnings)
+# CFLAGS += -Wstringop-overflow
+# -fstack-protector-strong: disabled — cosmopolitan libc provides its own canary mechanism
+# and stack-protector conflicts with its APE/TLS bootstrap, causing link failures
+# CFLAGS += -fstack-protector-strong
 # Runtime buffer overflow detection for libc functions
 CFLAGS += -D_FORTIFY_SOURCE=2
 CFLAGS += -I.
@@ -235,7 +246,7 @@ $(OBJS_DIR)/charsetjis.o: charsetjis.c charsetjis.def
 $(OBJS_DIR)/modes/stb.o: modes/stb.c modes/stb_image.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<
 	$(cmd)  mkdir -p $(dir $@)
-	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-error -Wno-double-promotion -Wno-sign-conversion -Wno-conversion -Wno-unused-but-set-variable -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+	$(cmd)  $(CC) $(DEFINES) $(CFLAGS) -Wno-error -Wno-double-promotion -Wno-sign-conversion -Wno-conversion -Wno-unused-but-set-variable -Wno-duplicated-branches -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 # libunicode and libregexp are vendored QuickJS code: relax warnings
 $(OBJS_DIR)/libunicode.o: libunicode.c libunicode.h libunicode-table.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<
@@ -262,7 +273,7 @@ $(OBJS_DIR)/libqhtml/xmlparse.o: libqhtml/xmlparse.c libqhtml/css.h libqhtml/htm
 $(OBJS_DIR)/third_party/lua/lua-amalg.o: third_party/lua/lua-amalg.c third_party/lua/lua-amalg.h Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC -c $<
 	$(cmd)  mkdir -p $(dir $@)
-	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -Wno-sign-conversion -Wno-conversion -Wno-bad-function-cast -Wno-cast-qual -MT $@ -MF $(@:.o=.d) -o $@ -c $<
+	$(cmd)  $(CC) $(CFLAGS) -Wno-error -Wno-format-nonliteral -Wno-null-dereference -Wno-unused-value -Wno-sign-conversion -Wno-conversion -Wno-bad-function-cast -Wno-cast-qual -Wno-float-equal -Wno-duplicated-branches -MT $@ -MF $(@:.o=.d) -o $@ -c $<
 
 $(OBJS_DIR)/%.o: %.c Makefile | $(COSMOCC_DIR)/bin/cosmocc
 	$(echo) CC $(ECHO_CFLAGS) -c $<

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -342,53 +342,60 @@ static void c_colorize_line(QEColorizeContext *cp,
             }
             if (mode_flags & CLANG_REGEX) {
                 /* XXX: should use more context to tell regex from divide */
-                char32_t prev = ' ';
-                for (i1 = start; i1 > indent; ) {
-                    prev = str[--i1];
-                    if (!qe_isblank(prev))
+                /* Inner block limits 'prev' scope so gotos to parse_regex:
+                 * below don't skip its initialization (-Wjump-misses-init). */
+                {
+                    char32_t prev = ' ';
+                    for (i1 = start; i1 > indent; ) {
+                        prev = str[--i1];
+                        if (!qe_isblank(prev))
+                            break;
+                    }
+                    /* ignore end of comment in grep output */
+                    if (start > indent && str[start - 1] == '*' && cp->partial_file)
                         break;
-                }
-                /* ignore end of comment in grep output */
-                if (start > indent && str[start - 1] == '*' && cp->partial_file)
-                    break;
 
-                if (!qe_findchar("])", prev)
-                &&  (qe_findchar(" [({},;=<>!~^&|*/%?:", prev)
-                ||   sbuf[i1] == C_STYLE_KEYWORD
-                ||   (str[i] != ' ' && (str[i] != '=' || str[i + 1] != ' ')
-                &&    !(qe_isalnum(prev) || prev == ')')))) {
-                    /* parse regex */
-                    state |= IN_C_REGEX;
-                    delim = '/';
-                parse_regex:
-                    style = C_STYLE_REGEX;
-                    while (i < n) {
-                        c = str[i++];
-                        if (c == '\\') {
-                            i = colorize_skip_escape(str, i, n);
+                    if (!qe_findchar("])", prev)
+                    &&  (qe_findchar(" [({},;=<>!~^&|*/%?:", prev)
+                    ||   sbuf[i1] == C_STYLE_KEYWORD
+                    ||   (str[i] != ' ' && (str[i] != '=' || str[i + 1] != ' ')
+                    &&    !(qe_isalnum(prev) || prev == ')')))) {
+                        /* parse regex */
+                        state |= IN_C_REGEX;
+                        delim = '/';
+                    } else {
+                        break;  /* treat '/' as division operator */
+                    }
+                }
+                /* 'prev' is now out of scope; gotos from state-resume code land here */
+            parse_regex:
+                style = C_STYLE_REGEX;
+                while (i < n) {
+                    c = str[i++];
+                    if (c == '\\') {
+                        i = colorize_skip_escape(str, i, n);
+                    } else
+                    if (state & IN_C_CHARCLASS) {
+                        if (c == ']') {
+                            state &= ~IN_C_CHARCLASS;
+                        }
+                        /* ECMA 5: ignore '/' inside char classes */
+                    } else {
+                        if (c == '[') {
+                            state |= IN_C_CHARCLASS;
                         } else
-                        if (state & IN_C_CHARCLASS) {
-                            if (c == ']') {
-                                state &= ~IN_C_CHARCLASS;
+                        if (c == delim) {
+                            while (qe_isalnum_(str[i])) {
+                                i++;
                             }
-                            /* ECMA 5: ignore '/' inside char classes */
-                        } else {
-                            if (c == '[') {
-                                state |= IN_C_CHARCLASS;
-                            } else
-                            if (c == delim) {
-                                while (qe_isalnum_(str[i])) {
-                                    i++;
-                                }
-                                state &= ~IN_C_REGEX;
-                                style = style0;
-                                break;
-                            }
+                            state &= ~IN_C_REGEX;
+                            style = style0;
+                            break;
                         }
                     }
-                    SET_STYLE(sbuf, start, i, C_STYLE_REGEX);
-                    continue;
                 }
+                SET_STYLE(sbuf, start, i, C_STYLE_REGEX);
+                continue;
             }
             break;
         case '%':
@@ -1906,51 +1913,58 @@ static void js_colorize_line(QEColorizeContext *cp,
             }
             if (mode_flags & CLANG_REGEX) {
                 /* XXX: should use more context to tell regex from divide */
-                char32_t prev = ' ';
-                for (i1 = start; i1 > indent; ) {
-                    prev = str[--i1];
-                    if (!qe_isblank(prev))
+                /* Inner block limits 'prev' scope so gotos to parse_regex:
+                 * below don't skip its initialization (-Wjump-misses-init). */
+                {
+                    char32_t prev = ' ';
+                    for (i1 = start; i1 > indent; ) {
+                        prev = str[--i1];
+                        if (!qe_isblank(prev))
+                            break;
+                    }
+                    /* ignore end of comment in grep output */
+                    if (start > indent && str[start - 1] == '*' && cp->partial_file)
                         break;
-                }
-                /* ignore end of comment in grep output */
-                if (start > indent && str[start - 1] == '*' && cp->partial_file)
-                    break;
 
-                if (!qe_findchar("])", prev)
-                &&  (qe_findchar(" [({},;=<>!~^&|*/%?:", prev)
-                ||   sbuf[i1] == C_STYLE_KEYWORD
-                ||   (str[i] != ' ' && (str[i] != '=' || str[i + 1] != ' ')
-                &&    !(qe_isalnum(prev) || prev == ')')))) {
-                    /* parse regex */
-                    state |= IN_C_REGEX;
-                    delim = '/';
-                parse_regex:
-                    style = C_STYLE_REGEX;
-                    while (i < n) {
-                        c = str[i++];
-                        if (c == '\\') {
-                            i = colorize_skip_escape(str, i, n);
+                    if (!qe_findchar("])", prev)
+                    &&  (qe_findchar(" [({},;=<>!~^&|*/%?:", prev)
+                    ||   sbuf[i1] == C_STYLE_KEYWORD
+                    ||   (str[i] != ' ' && (str[i] != '=' || str[i + 1] != ' ')
+                    &&    !(qe_isalnum(prev) || prev == ')')))) {
+                        /* parse regex */
+                        state |= IN_C_REGEX;
+                        delim = '/';
+                    } else {
+                        continue;  /* treat '/' as division operator */
+                    }
+                }
+                /* 'prev' is now out of scope; gotos from state-resume code land here */
+            parse_regex:
+                style = C_STYLE_REGEX;
+                while (i < n) {
+                    c = str[i++];
+                    if (c == '\\') {
+                        i = colorize_skip_escape(str, i, n);
+                    } else
+                    if (state & IN_C_CHARCLASS) {
+                        if (c == ']') {
+                            state &= ~IN_C_CHARCLASS;
+                        }
+                        /* ECMA 5: ignore '/' inside char classes */
+                    } else {
+                        if (c == '[') {
+                            state |= IN_C_CHARCLASS;
                         } else
-                        if (state & IN_C_CHARCLASS) {
-                            if (c == ']') {
-                                state &= ~IN_C_CHARCLASS;
+                        if (c == delim) {
+                            while (qe_isalnum_(str[i])) {
+                                i++;
                             }
-                            /* ECMA 5: ignore '/' inside char classes */
-                        } else {
-                            if (c == '[') {
-                                state |= IN_C_CHARCLASS;
-                            } else
-                            if (c == delim) {
-                                while (qe_isalnum_(str[i])) {
-                                    i++;
-                                }
-                                state &= ~IN_C_REGEX;
-                                break;
-                            }
+                            state &= ~IN_C_REGEX;
+                            break;
                         }
                     }
-                    break;
                 }
+                break;
             }
             continue;
         case '#':       /* preprocessor */

--- a/lang/elixir.c
+++ b/lang/elixir.c
@@ -144,8 +144,7 @@ static void elixir_colorize_line(QEColorizeContext *cp,
             }
         parse_string:
             sep = (char32_t)(unsigned char)elixir_delim2[state & 15];
-            style = (state & IN_ELIXIR_TRIPLE) ?
-                ELIXIR_STYLE_HEREDOC : ELIXIR_STYLE_STRING;
+            style = ELIXIR_STYLE_STRING;  /* HEREDOC == STRING: same QE_STYLE_STRING value */
             while (i < n) {
                 c = str[i++];
                 if (c == '\\') {

--- a/lang/erlang.c
+++ b/lang/erlang.c
@@ -233,10 +233,8 @@ static void erlang_colorize_line(QEColorizeContext *cp,
             if (check_fcall(str, i)) {
                 style = ERLANG_STYLE_FUNCTION;
             } else
-            if (qe_islower((u8)keyword[0])) {
-                style = ERLANG_STYLE_ATOM;
-            } else {
-                style = ERLANG_STYLE_IDENTIFIER;
+            {
+                style = ERLANG_STYLE_IDENTIFIER;  /* ATOM == IDENTIFIER: same QE_STYLE_DEFAULT value */
             }
             SET_STYLE(sbuf, start, i, style);
             continue;

--- a/lang/wolfram.c
+++ b/lang/wolfram.c
@@ -164,11 +164,14 @@ static void wolfram_colorize_line(QEColorizeContext *cp,
             }
             break;
         default:
-            /* parse numbers */
+            /* parse numbers: NNN, .NNN, NNN^^... (based), NNN.NNN, etc. */
             base = 10;
-            if (c == '.' && qe_isdigit(str[i]))
-                goto in_number;
-            if (qe_isdigit(c)) {
+            if (c == '.' && qe_isdigit(str[i])) {
+                /* floating-point starting with '.': scan fractional digits directly.
+                 * Refactored from 'goto in_number' to avoid -Wjump-misses-init. */
+                while (qe_digit_value(str[i]) < base)
+                    i++;
+            } else if (qe_isdigit(c)) {
                 int value = 0;
                 while (qe_isdigit(str[i])) {
                     value = value * 10 + (int)(str[i++] - '0');
@@ -181,25 +184,29 @@ static void wolfram_colorize_line(QEColorizeContext *cp,
                 }
                 if (str[i] == '.') {
                     i++;
-                in_number:
                     while (qe_digit_value(str[i]) < base)
                         i++;
                 }
-                if (str[i] == '`') {
-                    i++;
-                    if (str[i] == '`')
-                        i++;
-                    while (qe_isdigit(str[i]))
-                        i++;
-                }
-                if (str[i] == '*' && str[i + 1] == '^' && qe_isdigit(str[i + 2])) {
-                    i += 3;
-                    while (qe_isdigit(str[i]))
-                        i++;
-                }
-                style = WOLFRAM_STYLE_NUMBER;
-                break;
+            } else {
+                /* not a number — fall through to identifier/keyword parsing */
+                goto parse_identifier;
             }
+            /* common number suffix: precision mark (`), scientific (*^N) */
+            if (str[i] == '`') {
+                i++;
+                if (str[i] == '`')
+                    i++;
+                while (qe_isdigit(str[i]))
+                    i++;
+            }
+            if (str[i] == '*' && str[i + 1] == '^' && qe_isdigit(str[i + 2])) {
+                i += 3;
+                while (qe_isdigit(str[i]))
+                    i++;
+            }
+            style = WOLFRAM_STYLE_NUMBER;
+            break;
+        parse_identifier:
             /* parse identifiers and keywords */
             if (c == '$' || c == '#' || qe_isalpha_(c)) {
                 i += wolfram_get_identifier(kbuf, countof(kbuf), c, str, i, n);

--- a/libqhtml/cssparse.c
+++ b/libqhtml/cssparse.c
@@ -97,8 +97,11 @@ static int css_get_length(int *length_ptr, int *unit_ptr, const char *p)
      * CSS_UNIT_xxx values */
     unit = css_get_enum(p, "px,%,ex,em,mm,in,cm,pt,pc");
     if (unit < 0) {
-        /* only 0 is valid without unit */
+        /* only 0 is valid without unit: exact zero check is intentional here */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
         if (f != 0.0 || *p != '\0')
+#pragma GCC diagnostic pop
             return -1;
         num = 0;
         unit = CSS_UNIT_NONE;

--- a/libregexp.c
+++ b/libregexp.c
@@ -1444,11 +1444,13 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
                     }
                     return re_parse_error(s, "back reference out of range in regular expression");
                 }
-            emit_back_reference:
-                last_atom_start = s->byte_code.size;
-                last_capture_count = s->capture_count;
-                re_emit_op_u8(s, REOP_back_reference + is_backward_dir, c);
             }
+            /* 'q' out of scope; label moved here so goto emit_back_reference
+             * no longer skips 'q' initialization (-Wjump-misses-init). */
+        emit_back_reference:
+            last_atom_start = s->byte_code.size;
+            last_capture_count = s->capture_count;
+            re_emit_op_u8(s, REOP_back_reference + is_backward_dir, c);
             break;
         default:
             goto parse_class_atom;

--- a/session.c
+++ b/session.c
@@ -180,7 +180,12 @@ static ssize_t write_all_timeout(int fd, const char *buf, size_t len,
         if (res < 0) {
             if (errno == EINTR)
                 continue;
+            /* POSIX permits EAGAIN == EWOULDBLOCK; check both for portability.
+             * -Wlogical-op false positive on platforms where they're equal (e.g. Linux). */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
+#pragma GCC diagnostic pop
                 if (timeout_ms == 0)
                     return -1;
                 struct pollfd pfd = { .fd = fd, .events = POLLOUT };
@@ -212,7 +217,11 @@ static ssize_t read_all(int fd, char *buf, size_t len) {
         if (res < 0) {
             if (errno == EINTR)
                 continue;
+            /* POSIX permits EAGAIN == EWOULDBLOCK; see write_all_timeout comment */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
             if (errno == EAGAIN || errno == EWOULDBLOCK)
+#pragma GCC diagnostic pop
                 return ret - (ssize_t)len;
             return -1;
         }
@@ -562,7 +571,11 @@ static void server_mainloop(void) {
                 }
             } else if (len == 0) {
                 server.running = 0;
+            /* POSIX permits EAGAIN == EWOULDBLOCK; see write_all_timeout comment */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
             } else if (errno != EAGAIN && errno != EINTR && errno != EWOULDBLOCK) {
+#pragma GCC diagnostic pop
                 server.running = 0;
             }
         }

--- a/unix.c
+++ b/unix.c
@@ -349,7 +349,12 @@ ssize_t qe_write_timeout(int fd, const char *buf, size_t len, int timeout_ms) {
         if (res < 0) {
             if (errno == EINTR)
                 continue;
+            /* POSIX permits EAGAIN == EWOULDBLOCK; check both for portability.
+             * -Wlogical-op false positive on platforms where they're equal (e.g. Linux). */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
+#pragma GCC diagnostic pop
                 if (timeout_ms == 0)
                     return -1;
                 struct pollfd pfd = { .fd = fd, .events = POLLOUT };


### PR DESCRIPTION
## Summary

Enables four of the six compiler warning flags that were evaluated but deferred in #73, and documents why the remaining two cannot be enabled.

**Enabled:**
- `-Wlogical-op` — `EAGAIN == EWOULDBLOCK` on Linux/cosmocc made the standard POSIX `errno == EAGAIN || errno == EWOULDBLOCK` idiom fire. Fixed with `#pragma GCC diagnostic ignored "-Wlogical-op"` at 4 sites (unix.c, session.c).
- `-Wjump-misses-init` — 4 goto sites jumped into blocks containing initialized variables. Fixed by restructuring scopes in lang/clang.c (×2), libregexp.c, and lang/wolfram.c so the label is outside the declaring scope.
- `-Wfloat-equal` — All warnings were in vendored code (lua) plus one intentional exact-zero CSS check. Suppressed in vendored code via Makefile rule; one `#pragma` in libqhtml/cssparse.c.
- `-Wduplicated-branches` — Two lang files had style enums where different names mapped to the same constant (elixir: HEREDOC==STRING, erlang: ATOM==IDENTIFIER); collapsed those branches. Vendored code suppressed via Makefile rules.

**Still disabled (commented in Makefile with rationale):**
- `-Wstringop-overflow` — GCC false-positives on heap buffers inferred as `[0]` from `malloc`.
- `-fstack-protector-strong` — Conflicts with cosmopolitan libc's APE bootstrap (TLS/canary setup causes link failures).

## Test plan

- [x] `make clean && make` — zero warnings, zero errors
- [x] `make test` — 344/344 tests pass

https://claude.ai/code/session_01Me2WjzXsFjR4CKCvp9xgii